### PR TITLE
Actually undeprecate PulseProxy

### DIFF
--- a/src/mantle/pulsar/pulse/PulseProxy.java
+++ b/src/mantle/pulsar/pulse/PulseProxy.java
@@ -10,7 +10,6 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD})
 @Documented
-@Deprecated
 public @interface PulseProxy {
 
     /**


### PR DESCRIPTION
When @progwml6 "undeprecated" the PulseProxy, he only removed the javadoc with the deprecation notice. This actually undeprecates it. Silly prog. :P 
