### PR TITLE
Fixed a couple of off-by-one errors in CraftingItem.java

### DIFF
--- a/src/mantle/items/abstracts/CraftingItem.java
+++ b/src/mantle/items/abstracts/CraftingItem.java
@@ -45,8 +45,8 @@ public class CraftingItem extends Item
     @SideOnly(Side.CLIENT)
     public IIcon getIconFromDamage (int meta)
     {
-        int arr = MathHelper.clamp_int(meta, 0, unlocalizedNames.length);
-        if(arr > icons.length)
+        int arr = MathHelper.clamp_int(meta, 0, unlocalizedNames.length - 1);
+        if(arr >= icons.length)
             return icons[0];
         return icons[arr];
     }
@@ -66,7 +66,7 @@ public class CraftingItem extends Item
 
     public String getUnlocalizedName (ItemStack stack)
     {
-        int arr = MathHelper.clamp_int(stack.getItemDamage(), 0, unlocalizedNames.length);
+        int arr = MathHelper.clamp_int(stack.getItemDamage(), 0, unlocalizedNames.length - 1);
         return getUnlocalizedName() + "." + unlocalizedNames[arr];
     }
 


### PR DESCRIPTION
There are two cases in CraftingItem.java where MathHelper.clamp_int was used with an improper range (the clamp_int range is inclusive of both min and max).  And there is another case (line 49-51) that could result in icons[icons.length], which is out of range.