### PR TITLE
Updated source compat to Forge 1.7.10-10.13.4.1448 and snapshot 20140925

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,9 +75,10 @@ if (System.getenv().ARTIFACT_VERSION != null) {
 version = "${config.minecraft_version}-${artifact_version}"
 
 minecraft {
-    version = config.minecraft_version + "-" + config.forge_version
+    version = config.forge_version + "-" + config.minecraft_version
     runDir = 'run'
     replace '${version}', project.version
+    mappings = "snapshot_${config.snapshot}"
 }
 
 

--- a/build.properties
+++ b/build.properties
@@ -1,3 +1,4 @@
 mod_version=0.3.2
 minecraft_version=1.7.10
-forge_version=10.13.0.1187
+forge_version=10.13.4.1448
+snapshot=20140925

--- a/src/mantle/blocks/abstracts/AdaptiveInventoryLogic.java
+++ b/src/mantle/blocks/abstracts/AdaptiveInventoryLogic.java
@@ -76,7 +76,7 @@ public abstract class AdaptiveInventoryLogic extends InventoryLogic implements I
 
                             stack.stackSize -= itemSize;
                             EntityItem entityitem = new EntityItem(worldObj, (double) ((float) xCoord + jumpX + offsetX), (double) ((float) yCoord + jumpY),
-                                    (double) ((float) zCoord + jumpZ + offsetZ), new ItemStack(stack.getItem(), itemSize, stack.getItemDamage()));
+                                    (double) ((float) zCoord + jumpZ + offsetZ), new ItemStack(stack.getItem(), itemSize, stack.getMetadata()));
 
                             if (stack.hasTagCompound())
                             {

--- a/src/mantle/blocks/abstracts/InventoryBlock.java
+++ b/src/mantle/blocks/abstracts/InventoryBlock.java
@@ -97,7 +97,7 @@ public abstract class InventoryBlock extends BlockContainer
 
                         stack.stackSize -= itemSize;
                         EntityItem entityitem = new EntityItem(par1World, (double) ((float) x + jumpX), (double) ((float) y + jumpY), (double) ((float) z + jumpZ), new ItemStack(stack.getItem(),
-                                itemSize, stack.getItemDamage()));
+                                itemSize, stack.getMetadata()));
 
                         if (stack.hasTagCompound())
                         {
@@ -188,7 +188,7 @@ public abstract class InventoryBlock extends BlockContainer
     public abstract String getTextureDomain (int textureNameIndex);
 
     @Override
-    public void registerBlockIcons (IIconRegister iconRegister)
+    public void registerIcons (IIconRegister iconRegister)
     {
         String[] textureNames = getTextureNames();
         this.icons = new IIcon[textureNames.length];

--- a/src/mantle/blocks/abstracts/MultiItemBlock.java
+++ b/src/mantle/blocks/abstracts/MultiItemBlock.java
@@ -52,7 +52,7 @@ public class MultiItemBlock extends ItemBlock
     public String getUnlocalizedName (ItemStack itemstack)
     {
 
-        int pos = MathHelper.clamp_int(itemstack.getItemDamage(), 0, (specialIndex[0] > -1) ? specialIndex[0] : (blockType.length - 1));
+        int pos = MathHelper.clamp_int(itemstack.getMetadata(), 0, (specialIndex[0] > -1) ? specialIndex[0] : (blockType.length - 1));
         int sbIndex = (specialIndex[1] > -1) ? pos : (specialIndex[1] - pos);
         if (sbIndex < 0)
             sbIndex = -1 * sbIndex;

--- a/src/mantle/blocks/abstracts/MultiServantLogic.java
+++ b/src/mantle/blocks/abstracts/MultiServantLogic.java
@@ -168,8 +168,8 @@ public class MultiServantLogic extends TileEntity implements IServantLogic, IDeb
     @Override
     public void onDataPacket (NetworkManager net, S35PacketUpdateTileEntity packet)
     {
-        readCustomNBT(packet.func_148857_g());
-        worldObj.func_147479_m(xCoord, yCoord, zCoord);
+        readCustomNBT(packet.getNbtCompound());
+        worldObj.markBlockForRenderUpdate(xCoord, yCoord, zCoord);
         worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
     }
 
@@ -192,7 +192,7 @@ public class MultiServantLogic extends TileEntity implements IServantLogic, IDeb
 
     public World getWorld ()
     {
-        return this.getWorldObj();
+        return this.getWorld();
     }
 
     @Deprecated

--- a/src/mantle/client/RenderItemCopy.java
+++ b/src/mantle/client/RenderItemCopy.java
@@ -112,7 +112,7 @@ public class RenderItemCopy extends Render
 
                     f5 = 1.0F;
                     //TODO renderBlockAsItem
-                    this.itemRenderBlocks.renderBlockAsItem(block, itemstack.getItemDamage(), f5);
+                    this.itemRenderBlocks.renderBlockAsItem(block, itemstack.getMetadata(), f5);
                     GL11.glPopMatrix();
                 }
             }
@@ -132,7 +132,7 @@ public class RenderItemCopy extends Render
                         GL11.glScalef(0.5F, 0.5F, 0.5F);
                     }
 
-                    for (int k = 0; k < itemstack.getItem().getRenderPasses(itemstack.getItemDamage()); ++k)
+                    for (int k = 0; k < itemstack.getItem().getRenderPasses(itemstack.getCurrentDurability()); ++k)
                     {
                         this.random.setSeed(187L);
                         IIcon icon = itemstack.getItem().getIcon(itemstack, k);
@@ -354,7 +354,7 @@ public class RenderItemCopy extends Render
         }
         else
         {
-            l = par3ItemStack.getItemDamage();
+            l = par3ItemStack.getCurrentDurability();
         }
         Object object = par3ItemStack.getItem() == null ? null : par3ItemStack.getIconIndex();
         float f;
@@ -566,8 +566,8 @@ public class RenderItemCopy extends Render
 
             if (par3ItemStack.isItemDamaged())
             {
-                int k = (int) Math.round(13.0D - (double) par3ItemStack.getItemDamageForDisplay() * 13.0D / (double) par3ItemStack.getMaxDamage());
-                int l = (int) Math.round(255.0D - (double) par3ItemStack.getItemDamageForDisplay() * 255.0D / (double) par3ItemStack.getMaxDamage());
+                int k = (int) Math.round(13.0D - (double) par3ItemStack.getCurrentDurability() * 13.0D / (double) par3ItemStack.getMaxDurability());
+                int l = (int) Math.round(255.0D - (double) par3ItemStack.getCurrentDurability() * 255.0D / (double) par3ItemStack.getMaxDurability());
                 GL11.glDisable(GL11.GL_LIGHTING);
                 GL11.glDisable(GL11.GL_DEPTH_TEST);
                 GL11.glDisable(GL11.GL_TEXTURE_2D);

--- a/src/mantle/client/SmallFontRenderer.java
+++ b/src/mantle/client/SmallFontRenderer.java
@@ -526,7 +526,7 @@ public class SmallFontRenderer implements IResourceManagerReloadListener
             else
             {
                 j = ' ';
-                for (char c : ChatAllowedCharacters.allowedCharacters)
+                for (char c : ChatAllowedCharacters.allowedCharactersArray)
                 {
                     if (c == c0)
                     {
@@ -539,7 +539,7 @@ public class SmallFontRenderer implements IResourceManagerReloadListener
                 {
                     do
                     {
-                        k = this.fontRandom.nextInt(ChatAllowedCharacters.allowedCharacters.length);
+                        k = this.fontRandom.nextInt(ChatAllowedCharacters.allowedCharactersArray.length);
                     } while (this.charWidth[j + 32] != this.charWidth[k + 32]);
 
                     j = k;

--- a/src/mantle/items/Manual.java
+++ b/src/mantle/items/Manual.java
@@ -60,7 +60,7 @@ public class Manual extends CraftingItem
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void addInformation (ItemStack stack, EntityPlayer player, List list, boolean par4)
     {
-        list.add("\u00a7o" + StatCollector.translateToLocal(BookDataStore.getBookfromID(stack.getItemDamage()).toolTip));
+        list.add("\u00a7o" + StatCollector.translateToLocal(BookDataStore.getBookfromID(stack.getMetadata()).toolTip));
     }
 
     @Override

--- a/src/mantle/items/abstracts/CraftingItem.java
+++ b/src/mantle/items/abstracts/CraftingItem.java
@@ -27,7 +27,7 @@ public class CraftingItem extends Item
         {
             this.setCreativeTab(tab);
         }
-        this.setMaxDamage(0);
+        this.setMaxDurability(0);
         this.setHasSubtypes(true);
         this.textureNames = tex;
         this.unlocalizedNames = names;
@@ -66,7 +66,7 @@ public class CraftingItem extends Item
 
     public String getUnlocalizedName (ItemStack stack)
     {
-        int arr = MathHelper.clamp_int(stack.getItemDamage(), 0, unlocalizedNames.length);
+        int arr = MathHelper.clamp_int(stack.getMetadata(), 0, unlocalizedNames.length);
         return getUnlocalizedName() + "." + unlocalizedNames[arr];
     }
 

--- a/src/mantle/utils/CraftingHandler.java
+++ b/src/mantle/utils/CraftingHandler.java
@@ -324,6 +324,6 @@ public class CraftingHandler {
     }
 
     public static boolean compdamage (ItemStack a, ItemStack b) {
-        return a.getItemDamage() != b.getItemDamage() || a.getItemDamage() == OreDictionary.WILDCARD_VALUE || b.getItemDamage() == OreDictionary.WILDCARD_VALUE;
+        return a.getCurrentDurability() != b.getCurrentDurability() || a.getCurrentDurability() == OreDictionary.WILDCARD_VALUE || b.getCurrentDurability() == OreDictionary.WILDCARD_VALUE;
     }
 }

--- a/src/mantle/utils/ItemMetaWrapper.java
+++ b/src/mantle/utils/ItemMetaWrapper.java
@@ -15,7 +15,7 @@ public class ItemMetaWrapper {
     public ItemMetaWrapper(ItemStack stack)
     {
         this.item = stack.getItem();
-        this.meta = stack.getItemDamage();
+        this.meta = stack.getMetadata();
     }
 
     @Override

--- a/src/mantle/utils/ItemStackNBTWrapper.java
+++ b/src/mantle/utils/ItemStackNBTWrapper.java
@@ -22,7 +22,7 @@ public class ItemStackNBTWrapper {
     @Override
     public int hashCode() {
         int result = stack.getItem() != null ? stack.getItem().hashCode() : 0;
-        result = 31 * result + stack.getItemDamage();
+        result = 31 * result + stack.getMetadata();
         result = 31 * result + (stack.getTagCompound() != null ? stack.getTagCompound().hashCode() : 0);
         result = 31 * result + stack.stackSize;
         return result;

--- a/src/mantle/utils/RecipeRemover.java
+++ b/src/mantle/utils/RecipeRemover.java
@@ -75,7 +75,7 @@ public class RecipeRemover
 
     public static void removeFurnaceRecipe (ItemStack resultItem)
     {
-        Map<ItemStack, ItemStack> recipes = FurnaceRecipes.smelting().getSmeltingList();
+        Map<ItemStack, ItemStack> recipes = FurnaceRecipes.instance().getSmeltingList();
         recipes.remove(resultItem);
     }
 


### PR DESCRIPTION
I did a quick update to work with newer MCP mappings (20140925), but I recommend you take a hard look at all of the updated itemStack calls to make sure damage/durability/metadata is used correctly.