### PR TITLE
Fix infinite loop of getWorld inside of MultiServantLogic.

### DIFF
--- a/src/mantle/blocks/abstracts/MultiServantLogic.java
+++ b/src/mantle/blocks/abstracts/MultiServantLogic.java
@@ -192,7 +192,7 @@ public class MultiServantLogic extends TileEntity implements IServantLogic, IDeb
 
     public World getWorld ()
     {
-        return this.getWorld();
+        return super.getWorld();
     }
 
     @Deprecated


### PR DESCRIPTION
Yes I am a SlimeKnights but @bonii-xx isn't on for me to ask, so i'll create a PR instead of getting yelled at by him.


In #44, someone has commented that there was a infinite loop created inside of MultiServantLogic when the mappings got updated.

I looked into it, and inside of eclipse  the "this.getWorld()" just links me back to the "public World getWorld ()" inside of MultiServantLogic and not inside the TitleEntity class.