### PR TITLE
Add base classes for Slabs and Stairs

### DIFF
--- a/src/main/java/slimeknights/mantle/block/BlockStairsBase.java
+++ b/src/main/java/slimeknights/mantle/block/BlockStairsBase.java
@@ -9,5 +9,6 @@ public class BlockStairsBase extends BlockStairs {
   public BlockStairsBase(IBlockState modelState) {
     super(modelState);
     this.useNeighborBrightness = true;
+    this.setCreativeTab(modelState.getBlock().getCreativeTabToDisplayOn());
   }
 }

--- a/src/main/java/slimeknights/mantle/block/BlockStairsBase.java
+++ b/src/main/java/slimeknights/mantle/block/BlockStairsBase.java
@@ -1,0 +1,13 @@
+package slimeknights.mantle.block;
+
+import net.minecraft.block.BlockStairs;
+import net.minecraft.block.state.IBlockState;
+
+// Mojang made the constructor for stairs protected, so this class is basically a wrapper to change that and fix a lighting error
+public class BlockStairsBase extends BlockStairs {
+
+  public BlockStairsBase(IBlockState modelState) {
+    super(modelState);
+    this.useNeighborBrightness = true;
+  }
+}

--- a/src/main/java/slimeknights/mantle/block/EnumBlockSlab.java
+++ b/src/main/java/slimeknights/mantle/block/EnumBlockSlab.java
@@ -1,0 +1,119 @@
+package slimeknights.mantle.block;
+
+import java.util.List;
+
+import net.minecraft.block.BlockSlab;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.properties.PropertyEnum;
+import net.minecraft.block.state.BlockStateContainer;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.IStringSerializable;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+public abstract class EnumBlockSlab<E extends Enum<E> & EnumBlock.IEnumMeta & IStringSerializable> extends BlockSlab {
+
+  public final PropertyEnum<E> prop;
+  private final E[] values;
+
+  private static PropertyEnum<?> tmp;
+
+  public EnumBlockSlab(Material material, PropertyEnum<E> prop, Class<E> clazz) {
+    super(preInit(material, prop));
+    this.prop = prop;
+    values = clazz.getEnumConstants();
+    this.setDefaultState(this.blockState.getBaseState().withProperty(BlockSlab.HALF, BlockSlab.EnumBlockHalf.BOTTOM));
+    this.useNeighborBrightness = true;
+  }
+
+  private static Material preInit(Material material, PropertyEnum<?> property) {
+    tmp = property;
+    return material;
+  }
+
+  @SideOnly(Side.CLIENT)
+  @Override
+  public void getSubBlocks(Item itemIn, CreativeTabs tab, List<ItemStack> list) {
+    for(E type : values) {
+      list.add(new ItemStack(this, 1, type.getMeta()));
+    }
+  }
+
+  @Override
+  protected BlockStateContainer createBlockState() {
+    if(prop == null) {
+      return new BlockStateContainer(this, HALF, tmp);
+    }
+    return new BlockStateContainer(this, HALF, prop);
+  }
+
+
+  /**
+   * Convert the given metadata into a BlockState for this Block
+   */
+  public IBlockState getStateFromMeta(int meta) {
+    return this.getDefaultState().withProperty(prop, fromMeta(meta & 7))
+                                 .withProperty(HALF, (meta & 8) == 0 ? BlockSlab.EnumBlockHalf.BOTTOM : BlockSlab.EnumBlockHalf.TOP);
+  }
+
+  /**
+   * Convert the BlockState into the correct metadata value
+   */
+  public int getMetaFromState(IBlockState state)
+  {
+      int i = 0;
+      i = i | state.getValue(prop).getMeta();
+
+      if (state.getValue(HALF) == BlockSlab.EnumBlockHalf.TOP)
+      {
+          i |= 8;
+      }
+
+      return i;
+  }
+
+  @Override
+  public int damageDropped(IBlockState state) {
+    return state.getValue(prop).getMeta();
+  }
+
+  protected E fromMeta(int meta) {
+    if(meta < 0 || meta >= values.length) {
+      meta = 0;
+    }
+
+    return values[meta];
+  }
+  
+  @Override
+  public IProperty<?> getVariantProperty() {
+    return prop;
+  }
+  
+  public Comparable<?> getTypeForItem(ItemStack stack) {
+      return fromMeta(stack.getItemDamage() & 7);
+  }
+
+  @Override
+  public String getUnlocalizedName(int meta) {
+    return super.getUnlocalizedName() + "." + fromMeta(meta & 7).getName();
+  }
+  
+  /**
+   * Gets the full variant of the slab, as double slabs are not used here
+   * @param state Input slab state, in most cases state.getValue() with a switch is all you need
+   * @return An IBlockState of the full block
+   */
+  public abstract IBlockState getFullBlock(IBlockState state);
+  
+  // all our slabs are single
+  @Override
+  public boolean isDouble() {
+    return false;
+  }
+
+}

--- a/src/main/java/slimeknights/mantle/item/ItemBlockSlab.java
+++ b/src/main/java/slimeknights/mantle/item/ItemBlockSlab.java
@@ -1,0 +1,130 @@
+package slimeknights.mantle.item;
+
+import java.util.Collection;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockSlab;
+import net.minecraft.block.SoundType;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.fml.common.registry.GameData;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import slimeknights.mantle.block.EnumBlockSlab;
+
+public class ItemBlockSlab extends ItemBlockMeta {
+  
+  public EnumBlockSlab<?> slab;
+
+  public ItemBlockSlab(EnumBlockSlab<?> block) {
+    super(block);
+    this.slab = block;
+  }
+
+  /**
+   * Called when a Block is right-clicked with this Item
+   */
+  public EnumActionResult onItemUse(ItemStack stack, EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ) {
+    // don't place the slab if unable to edit
+    if (stack.stackSize != 0 && player.canPlayerEdit(pos.offset(facing), facing, stack)) {
+      
+      // try placing the slab at the current position
+      // note that this requires the slab to be extended on the side the block was clicked
+      if (tryPlace(player, stack, world, pos, facing)) {
+        return EnumActionResult.SUCCESS;
+      }
+      // otherwise. try and place it in the block in front
+      else if (this.tryPlace(player, stack, world, pos.offset(facing), null)) {
+        return EnumActionResult.SUCCESS;
+      }
+      
+      return super.onItemUse(stack, player, world, pos, hand, facing, hitX, hitY, hitZ);
+    }
+    else {
+      return EnumActionResult.FAIL;
+    }
+  }
+
+  @Override
+  @SideOnly(Side.CLIENT)
+  public boolean canPlaceBlockOnSide(World world, BlockPos pos, EnumFacing side, EntityPlayer player, ItemStack stack)
+  {
+    BlockPos oldPos = pos;
+    Comparable<?> type = this.slab.getTypeForItem(stack);
+    IBlockState state = world.getBlockState(pos);
+
+    // first, try placing on the same block
+    if (state.getBlock() == this.slab) {
+      boolean flag = state.getValue(BlockSlab.HALF) == BlockSlab.EnumBlockHalf.TOP;
+
+      if ((side == EnumFacing.UP && !flag || side == EnumFacing.DOWN && flag) && type == state.getValue(this.slab.prop) && this.slab.getFullBlock(state) != null) {
+        return true;
+      }
+    }
+
+    // if that does not work, offset by one and try same type
+    pos = pos.offset(side);
+    state = world.getBlockState(pos);
+    return state.getBlock() == this.slab && type == state.getValue(this.slab.prop) ? true : super.canPlaceBlockOnSide(world, oldPos, side, player, stack);
+  }
+
+  private boolean tryPlace(EntityPlayer player, ItemStack stack, World worldIn, BlockPos pos, EnumFacing facing) {
+    IBlockState state = worldIn.getBlockState(pos);
+    Comparable<?> type = this.slab.getTypeForItem(stack);
+
+    if (state.getBlock() == this.slab) {
+      BlockSlab.EnumBlockHalf half = state.getValue(BlockSlab.HALF);
+
+      if (type == state.getValue(this.slab.prop)
+          && (facing == null
+            || facing == EnumFacing.UP && half == BlockSlab.EnumBlockHalf.BOTTOM
+            || facing == EnumFacing.DOWN && half == BlockSlab.EnumBlockHalf.TOP)) {
+        
+        IBlockState fullBlock = this.slab.getFullBlock(state);
+        if(fullBlock != null) {
+          AxisAlignedBB axisalignedbb = fullBlock.getCollisionBoundingBox(worldIn, pos);
+  
+          if (axisalignedbb != Block.NULL_AABB && worldIn.checkNoEntityCollision(axisalignedbb.offset(pos)) && worldIn.setBlockState(pos, fullBlock, 11)) {
+            SoundType soundtype = fullBlock.getBlock().getSoundType();
+            worldIn.playSound(player, pos, soundtype.getPlaceSound(), SoundCategory.BLOCKS, (soundtype.getVolume() + 1.0F) / 2.0F, soundtype.getPitch() * 0.8F);
+            --stack.stackSize;
+          }
+  
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+  
+  // adds the "half=bottom" to the item model, so it does not error
+  @SuppressWarnings("unchecked")
+  @SideOnly(Side.CLIENT)
+  public void registerItemModels() {
+    final Item item = this;
+    final ResourceLocation loc = GameData.getBlockRegistry().getNameForObject(block);
+
+    for(Comparable<?> o : (Collection<Comparable<?>>) mappingProperty.getAllowedValues()) {
+      int meta = block.getMetaFromState(block.getDefaultState().withProperty(mappingProperty, o));
+      String name = mappingProperty.getName(o);
+
+      ModelLoader.setCustomModelResourceLocation(item, meta, new ModelResourceLocation(loc, "half=bottom,"
+                                                                                              + mappingProperty.getName()
+                                                                                              + "=" + name));
+    }
+  }
+  
+}


### PR DESCRIPTION
The main slab class is an extension of the vanilla slab (for mod compatibility) and contains modified methods from EnumBlock. ItemBlockSlab extends ItemBlockMeta and contains modified methods from vanilla ItemSlab (ItemSlab's only functions needed to be changed anyways)

The base class for stairs is basically a wrapper to fix stairs not having a public constructor.