### PR TITLE
Add base stuff for a block with connected textures

### DIFF
--- a/src/main/java/slimeknights/mantle/block/BlockConnectedTexture.java
+++ b/src/main/java/slimeknights/mantle/block/BlockConnectedTexture.java
@@ -1,0 +1,94 @@
+package slimeknights.mantle.block;
+
+import javax.annotation.Nonnull;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.properties.PropertyBool;
+import net.minecraft.block.state.BlockStateContainer;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
+
+ /**
+  * Creates a block with textures that connect to other blocks
+  * <p>
+  * Based off a tutorial by Darkhax, used under the Creative Commons Zero 1.0 Universal license
+  */
+public class BlockConnectedTexture extends Block {
+    
+    // These are the properties used for determining whether or not a side is connected. They
+    // do NOT take up block IDs, they are unlisted properties
+    public static final PropertyBool CONNECTED_DOWN = PropertyBool.create("connected_down");
+    public static final PropertyBool CONNECTED_UP = PropertyBool.create("connected_up");
+    public static final PropertyBool CONNECTED_NORTH = PropertyBool.create("connected_north");
+    public static final PropertyBool CONNECTED_SOUTH = PropertyBool.create("connected_south");
+    public static final PropertyBool CONNECTED_WEST = PropertyBool.create("connected_west");
+    public static final PropertyBool CONNECTED_EAST = PropertyBool.create("connected_east");
+    
+    public BlockConnectedTexture(Material material) {
+        
+      super(material);
+      // By default none of the sides are connected
+      this.setDefaultState(this.blockState.getBaseState()
+                                          .withProperty(CONNECTED_DOWN, Boolean.FALSE)
+                                          .withProperty(CONNECTED_EAST, Boolean.FALSE)
+                                          .withProperty(CONNECTED_NORTH, Boolean.FALSE)
+                                          .withProperty(CONNECTED_SOUTH, Boolean.FALSE)
+                                          .withProperty(CONNECTED_UP, Boolean.FALSE)
+                                          .withProperty(CONNECTED_WEST, Boolean.FALSE));
+    }
+    
+    @Override
+    public IBlockState getActualState(IBlockState state, IBlockAccess world, BlockPos position) {
+        
+      // Creates the state to use for the block. This is where we check if every side is
+      // connectable or not.
+      return state.withProperty(CONNECTED_DOWN,  this.isSideConnectable(world, position, EnumFacing.DOWN))
+                  .withProperty(CONNECTED_EAST,  this.isSideConnectable(world, position, EnumFacing.EAST))
+                  .withProperty(CONNECTED_NORTH, this.isSideConnectable(world, position, EnumFacing.NORTH))
+                  .withProperty(CONNECTED_SOUTH, this.isSideConnectable(world, position, EnumFacing.SOUTH))
+                  .withProperty(CONNECTED_UP,    this.isSideConnectable(world, position, EnumFacing.UP))
+                  .withProperty(CONNECTED_WEST,  this.isSideConnectable(world, position, EnumFacing.WEST));
+    }
+
+    @Nonnull
+    @Override
+    protected BlockStateContainer createBlockState() {
+      return new BlockStateContainer(this, new IProperty[] { CONNECTED_DOWN, CONNECTED_UP, CONNECTED_NORTH, CONNECTED_SOUTH, CONNECTED_WEST, CONNECTED_EAST });
+    }
+    
+    // Since the block has state information but we are not switching the meta value, we have
+    // to override this method to return 0
+    @Override
+    public int getMetaFromState(IBlockState state) {
+      return 0;
+    }
+    
+    /**
+     * Checks if a specific side of a block can connect to this block. For this example, a side
+     * is connectable if the block is the same block as this one.
+     * 
+     * @param world The world to run the check in.
+     * @param pos The position of the block to check for.
+     * @param side The side of the block to check.
+     * @return Whether or not the side is connectable.
+     */
+    private boolean isSideConnectable(IBlockAccess world, BlockPos pos, EnumFacing side) {
+      final IBlockState original = world.getBlockState(pos);
+      final IBlockState connected = world.getBlockState(pos.offset(side));
+
+      return original != null && connected != null && canConnect(original, connected);
+    }
+    
+    /**
+     * Checks if this block should connect to another block
+     * @param state BlockState to check
+     * @return True if the block is valid to connect
+     */
+    protected boolean canConnect(@Nonnull IBlockState original, @Nonnull IBlockState connected) {
+      return original.getBlock() == connected.getBlock();
+    }
+}

--- a/src/main/java/slimeknights/mantle/block/EnumBlock.java
+++ b/src/main/java/slimeknights/mantle/block/EnumBlock.java
@@ -21,7 +21,7 @@ public class EnumBlock<E extends Enum<E> & EnumBlock.IEnumMeta & IStringSerializ
   public final PropertyEnum<E> prop;
   private final E[] values;
 
-  private static PropertyEnum<?> tmp;
+  protected static PropertyEnum<?> tmp;
 
   public EnumBlock(Material material, PropertyEnum<E> prop, Class<E> clazz) {
     super(preInit(material, prop));
@@ -29,7 +29,6 @@ public class EnumBlock<E extends Enum<E> & EnumBlock.IEnumMeta & IStringSerializ
     values = clazz.getEnumConstants();
   }
 
-  @SuppressWarnings("unchecked")
   private static Material preInit(Material material, PropertyEnum<?> property) {
     tmp = property;
     return material;

--- a/src/main/java/slimeknights/mantle/block/EnumBlockConnectedTexture.java
+++ b/src/main/java/slimeknights/mantle/block/EnumBlockConnectedTexture.java
@@ -1,0 +1,80 @@
+package slimeknights.mantle.block;
+
+import javax.annotation.Nonnull;
+
+import net.minecraft.block.material.Material;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.properties.PropertyEnum;
+import net.minecraft.block.state.BlockStateContainer;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.IStringSerializable;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
+
+ /**
+  * Creates a block with textures that connect to other blocks
+  * <p>
+  * Based off a tutorial by Darkhax, used under the Creative Commons Zero 1.0 Universal license
+  */
+public class EnumBlockConnectedTexture<E extends Enum<E> & EnumBlock.IEnumMeta & IStringSerializable> extends EnumBlock<E> {
+    
+    public EnumBlockConnectedTexture(Material material, PropertyEnum<E> prop, Class<E> clazz) {
+      super(material, prop, clazz);
+      
+      // By default none of the sides are connected
+      this.setDefaultState(this.blockState.getBaseState()
+                                          .withProperty(BlockConnectedTexture.CONNECTED_DOWN, Boolean.FALSE)
+                                          .withProperty(BlockConnectedTexture.CONNECTED_EAST, Boolean.FALSE)
+                                          .withProperty(BlockConnectedTexture.CONNECTED_NORTH, Boolean.FALSE)
+                                          .withProperty(BlockConnectedTexture.CONNECTED_SOUTH, Boolean.FALSE)
+                                          .withProperty(BlockConnectedTexture.CONNECTED_UP, Boolean.FALSE)
+                                          .withProperty(BlockConnectedTexture.CONNECTED_WEST, Boolean.FALSE));
+    }
+    
+    @Override
+    public IBlockState getActualState(IBlockState state, IBlockAccess world, BlockPos position) { 
+      // Creates the state to use for the block. This is where we check if every side is
+      // connectable or not.
+      return state.withProperty(BlockConnectedTexture.CONNECTED_DOWN,  this.isSideConnectable(world, position, EnumFacing.DOWN))
+                  .withProperty(BlockConnectedTexture.CONNECTED_EAST,  this.isSideConnectable(world, position, EnumFacing.EAST))
+                  .withProperty(BlockConnectedTexture.CONNECTED_NORTH, this.isSideConnectable(world, position, EnumFacing.NORTH))
+                  .withProperty(BlockConnectedTexture.CONNECTED_SOUTH, this.isSideConnectable(world, position, EnumFacing.SOUTH))
+                  .withProperty(BlockConnectedTexture.CONNECTED_UP,    this.isSideConnectable(world, position, EnumFacing.UP))
+                  .withProperty(BlockConnectedTexture.CONNECTED_WEST,  this.isSideConnectable(world, position, EnumFacing.WEST));
+    }
+    
+    @Nonnull
+    @Override
+    protected BlockStateContainer createBlockState() {
+      if(prop == null) {
+        return new BlockStateContainer(this, new IProperty[] { tmp, BlockConnectedTexture.CONNECTED_DOWN, BlockConnectedTexture.CONNECTED_UP, BlockConnectedTexture.CONNECTED_NORTH, BlockConnectedTexture.CONNECTED_SOUTH, BlockConnectedTexture.CONNECTED_WEST, BlockConnectedTexture.CONNECTED_EAST });
+      }
+      return new BlockStateContainer(this, new IProperty[] { prop, BlockConnectedTexture.CONNECTED_DOWN, BlockConnectedTexture.CONNECTED_UP, BlockConnectedTexture.CONNECTED_NORTH, BlockConnectedTexture.CONNECTED_SOUTH, BlockConnectedTexture.CONNECTED_WEST, BlockConnectedTexture.CONNECTED_EAST });
+    }
+    
+    /**
+     * Checks if a specific side of a block can connect to this block. For this example, a side
+     * is connectable if the block is the same block as this one.
+     * 
+     * @param world The world to run the check in.
+     * @param pos The position of the block to check for.
+     * @param side The side of the block to check.
+     * @return Whether or not the side is connectable.
+     */
+    private boolean isSideConnectable(IBlockAccess world, BlockPos pos, EnumFacing side) {
+      final IBlockState original = world.getBlockState(pos);
+      final IBlockState connected = world.getBlockState(pos.offset(side));
+      
+      return original != null && connected != null && canConnect(original, connected);
+    }
+    
+    /**
+     * Checks if this block should connect to another block
+     * @param state BlockState to check
+     * @return True if the block is valid to connect
+     */
+    protected boolean canConnect(IBlockState original, IBlockState connected) {
+      return connected.getBlock() == original.getBlock() && connected.getValue(prop) == original.getValue(prop);
+    }
+}

--- a/src/main/java/slimeknights/mantle/client/gui/book/element/BookElement.java
+++ b/src/main/java/slimeknights/mantle/client/gui/book/element/BookElement.java
@@ -41,22 +41,24 @@ public abstract class BookElement extends Gui {
   }
 
   public void renderToolTip(FontRenderer fontRenderer, ItemStack stack, int x, int y) {
-    List<String> list = stack.getTooltip(mc.thePlayer, mc.gameSettings.advancedItemTooltips);
-
-    for(int i = 0; i < list.size(); ++i) {
-      if(i == 0) {
-        list.set(i, stack.getRarity().rarityColor + list.get(i));
-      } else {
-        list.set(i, TextFormatting.GRAY + list.get(i));
+    if(stack != null) {
+      List<String> list = stack.getTooltip(mc.thePlayer, mc.gameSettings.advancedItemTooltips);
+      
+      for(int i = 0; i < list.size(); ++i) {
+        if(i == 0) {
+          list.set(i, stack.getRarity().rarityColor + list.get(i));
+        } else {
+          list.set(i, TextFormatting.GRAY + list.get(i));
+        }
       }
+	
+      FontRenderer font = stack.getItem().getFontRenderer(stack);
+      if(font == null) {
+        font = fontRenderer;
+      }
+      GuiUtils.drawHoveringText(list, x, y, GuiBook.PAGE_WIDTH, GuiBook.PAGE_HEIGHT, -1, font);
+      RenderHelper.disableStandardItemLighting();
     }
-
-    FontRenderer font = stack.getItem().getFontRenderer(stack);
-    if(font == null) {
-      font = fontRenderer;
-    }
-    GuiUtils.drawHoveringText(list, x, y, GuiBook.PAGE_WIDTH, GuiBook.PAGE_HEIGHT, -1, font);
-    RenderHelper.disableStandardItemLighting();
   }
 
   @Deprecated

--- a/src/main/resources/assets/mantle/blockstate/connected_example.json
+++ b/src/main/resources/assets/mantle/blockstate/connected_example.json
@@ -1,0 +1,96 @@
+{
+	"forge_marker": 1,
+    "defaults": {
+		"textures": {
+			"normal": "MOD:blocks/NAME_normal",
+			"u": "MOD:blocks/NAME_u",
+			"r": "MOD:blocks/NAME_r",
+			"ud": "MOD:blocks/NAME_ud",
+			"ul": "MOD:blocks/NAME_ul",
+			"ur": "MOD:blocks/NAME_ur",
+			"lr": "MOD:blocks/NAME_lr",
+			"udr": "MOD:blocks/NAME_udr",
+			"udl": "MOD:blocks/NAME_udl",
+			"ulr": "MOD:blocks/NAME_ulr",
+			"udlr": "MOD:blocks/NAME_udlr"
+		}
+	},
+	"variants": {
+		"inventory": { "model": "mantle:connected_0" },
+		"connected_down=false,connected_east=false,connected_north=false,connected_south=false,connected_up=false,connected_west=false": { "model": "mantle:connected_0" },
+
+		"connected_down=false,connected_east=false,connected_north=false,connected_south=false,connected_up=true,connected_west=false": { "model": "mantle:connected_1" },
+		"connected_down=true,connected_east=false,connected_north=false,connected_south=false,connected_up=false,connected_west=false": { "model": "mantle:connected_1", "x": 180 },
+		"connected_down=false,connected_east=false,connected_north=true,connected_south=false,connected_up=false,connected_west=false": { "model": "mantle:connected_1", "x": 90 },
+		"connected_down=false,connected_east=false,connected_north=false,connected_south=true,connected_up=false,connected_west=false": { "model": "mantle:connected_1", "x": -90 },
+		"connected_down=false,connected_east=false,connected_north=false,connected_south=false,connected_up=false,connected_west=true": { "model": "mantle:connected_1", "x": 90, "y": -90 },
+		"connected_down=false,connected_east=true,connected_north=false,connected_south=false,connected_up=false,connected_west=false": { "model": "mantle:connected_1", "x": 90, "y": 90 },
+
+		"connected_down=false,connected_east=true,connected_north=false,connected_south=false,connected_up=true,connected_west=false": { "model": "mantle:connected_2_angle" },
+		"connected_down=false,connected_east=false,connected_north=false,connected_south=false,connected_up=true,connected_west=true": { "model": "mantle:connected_2_angle", "y": 180 },
+		"connected_down=true,connected_east=true,connected_north=false,connected_south=false,connected_up=false,connected_west=false": { "model": "mantle:connected_2_angle", "x": 180 },
+		"connected_down=true,connected_east=false,connected_north=false,connected_south=false,connected_up=false,connected_west=true": { "model": "mantle:connected_2_angle", "x": 180, "y": 180 },
+		"connected_down=false,connected_east=false,connected_north=true,connected_south=false,connected_up=true,connected_west=false": { "model": "mantle:connected_2_angle", "y": -90 },
+		"connected_down=false,connected_east=false,connected_north=false,connected_south=true,connected_up=true,connected_west=false": { "model": "mantle:connected_2_angle", "y": 90 },
+		"connected_down=true,connected_east=false,connected_north=true,connected_south=false,connected_up=false,connected_west=false": { "model": "mantle:connected_2_angle", "x": 180, "y": -90 },
+		"connected_down=true,connected_east=false,connected_north=false,connected_south=true,connected_up=false,connected_west=false": { "model": "mantle:connected_2_angle", "x": 180, "y": 90 },
+		"connected_down=false,connected_east=true,connected_north=true,connected_south=false,connected_up=false,connected_west=false": { "model": "mantle:connected_2_angle", "x": 90 },
+		"connected_down=false,connected_east=true,connected_north=false,connected_south=true,connected_up=false,connected_west=false": { "model": "mantle:connected_2_angle", "x": -90 },
+		"connected_down=false,connected_east=false,connected_north=true,connected_south=false,connected_up=false,connected_west=true": { "model": "mantle:connected_2_angle", "x": 90, "y": -90 },
+		"connected_down=false,connected_east=false,connected_north=false,connected_south=true,connected_up=false,connected_west=true": { "model": "mantle:connected_2_angle", "x": -90, "y": 90 },
+
+		"connected_down=true,connected_east=false,connected_north=false,connected_south=false,connected_up=true,connected_west=false": { "model": "mantle:connected_2" },
+		"connected_down=false,connected_east=true,connected_north=false,connected_south=false,connected_up=false,connected_west=true": { "model": "mantle:connected_2", "x": -90, "y": 90  },
+		"connected_down=false,connected_east=false,connected_north=true,connected_south=true,connected_up=false,connected_west=false": { "model": "mantle:connected_2", "x": -90 },
+
+        "connected_down=true,connected_east=false,connected_north=false,connected_south=false,connected_up=true,connected_west=true": { "model": "mantle:connected_3_T1" },
+        "connected_down=true,connected_east=false,connected_north=false,connected_south=true,connected_up=true,connected_west=false": { "model": "mantle:connected_3_T1", "y": -90 },
+        "connected_down=true,connected_east=true,connected_north=false,connected_south=false,connected_up=true,connected_west=false": { "model": "mantle:connected_3_T1", "y": -180 },
+        "connected_down=true,connected_east=false,connected_north=true,connected_south=false,connected_up=true,connected_west=false": { "model": "mantle:connected_3_T1", "y": 90 },
+        "connected_down=false,connected_east=false,connected_north=true,connected_south=true,connected_up=false,connected_west=true": { "model": "mantle:connected_3_T1", "x": -90 },
+        "connected_down=false,connected_east=true,connected_north=true,connected_south=true,connected_up=false,connected_west=false": { "model": "mantle:connected_3_T1", "x": -90, "y": 180 },
+
+        "connected_down=false,connected_east=true,connected_north=false,connected_south=false,connected_up=true,connected_west=true": { "model": "mantle:connected_3_T2" },
+        "connected_down=false,connected_east=true,connected_north=false,connected_south=true,connected_up=false,connected_west=true": { "model": "mantle:connected_3_T2", "x": -90 },
+        "connected_down=true,connected_east=true,connected_north=false,connected_south=false,connected_up=false,connected_west=true": { "model": "mantle:connected_3_T2", "x": 180 },
+        "connected_down=false,connected_east=true,connected_north=true,connected_south=false,connected_up=false,connected_west=true": { "model": "mantle:connected_3_T2", "x": 90 },
+        "connected_down=false,connected_east=false,connected_north=true,connected_south=true,connected_up=true,connected_west=false": { "model": "mantle:connected_3_T2", "y": 90 },
+        "connected_down=true,connected_east=false,connected_north=true,connected_south=true,connected_up=false,connected_west=false": { "model": "mantle:connected_3_T2", "x": 180, "y": 90 },
+
+        "connected_down=false,connected_east=true,connected_north=false,connected_south=true,connected_up=true,connected_west=false": { "model": "mantle:connected_3_angle" },
+        "connected_down=false,connected_east=false,connected_north=false,connected_south=true,connected_up=true,connected_west=true": { "model": "mantle:connected_3_angle", "y": 90 },
+        "connected_down=false,connected_east=true,connected_north=true,connected_south=false,connected_up=true,connected_west=false": { "model": "mantle:connected_3_angle", "x": 90 },
+        "connected_down=true,connected_east=true,connected_north=true,connected_south=false,connected_up=false,connected_west=false": { "model": "mantle:connected_3_angle", "x": 180 },
+        "connected_down=true,connected_east=true,connected_north=false,connected_south=true,connected_up=false,connected_west=false": { "model": "mantle:connected_3_angle", "x": 270 },
+
+        "connected_down=true,connected_east=false,connected_north=false,connected_south=true,connected_up=false,connected_west=true": { "model": "mantle:connected_3_angle", "x": 180, "y": -180 },
+        "connected_down=true,connected_east=false,connected_north=true,connected_south=false,connected_up=false,connected_west=true": { "model": "mantle:connected_3_angle", "x": -90, "y": -180 },
+        "connected_down=false,connected_east=false,connected_north=true,connected_south=false,connected_up=true,connected_west=true": { "model": "mantle:connected_3_angle", "x": 90, "y": -90 },
+
+        "connected_down=true,connected_east=true,connected_north=false,connected_south=false,connected_up=true,connected_west=true": { "model": "mantle:connected_4_cross" },
+        "connected_down=false,connected_east=true,connected_north=true,connected_south=true,connected_up=false,connected_west=true": { "model": "mantle:connected_4_cross", "x": 90 },
+        "connected_down=true,connected_east=false,connected_north=true,connected_south=true,connected_up=true,connected_west=false": { "model": "mantle:connected_4_cross", "y": 90 },
+
+        "connected_down=true,connected_east=false,connected_north=true,connected_south=false,connected_up=true,connected_west=true": { "model": "mantle:connected_4_angle" },
+        "connected_down=true,connected_east=false,connected_north=true,connected_south=true,connected_up=false,connected_west=true": { "model": "mantle:connected_4_angle", "x": 90 },
+        "connected_down=false,connected_east=false,connected_north=true,connected_south=true,connected_up=true,connected_west=true": { "model": "mantle:connected_4_angle", "x": -90 },
+        "connected_down=true,connected_east=false,connected_north=false,connected_south=true,connected_up=true,connected_west=true": { "model": "mantle:connected_4_angle", "y": -90 },
+        "connected_down=true,connected_east=true,connected_north=true,connected_south=false,connected_up=true,connected_west=false": { "model": "mantle:connected_4_angle", "y": 90 },
+        "connected_down=true,connected_east=true,connected_north=false,connected_south=true,connected_up=true,connected_west=false": { "model": "mantle:connected_4_angle", "y": 180 },
+        "connected_down=false,connected_east=true,connected_north=true,connected_south=true,connected_up=true,connected_west=false": { "model": "mantle:connected_4_angle", "x": -90, "y": 180 },
+        "connected_down=true,connected_east=true,connected_north=true,connected_south=true,connected_up=false,connected_west=false": { "model": "mantle:connected_4_angle", "x": 90, "y": 180 },
+        "connected_down=false,connected_east=true,connected_north=false,connected_south=true,connected_up=true,connected_west=true": { "model": "mantle:connected_4_angle", "x": -90, "y": -90 },
+        "connected_down=true,connected_east=true,connected_north=false,connected_south=true,connected_up=false,connected_west=true": { "model": "mantle:connected_4_angle", "x": -270, "y": -90 },
+        "connected_down=false,connected_east=true,connected_north=true,connected_south=false,connected_up=true,connected_west=true": { "model": "mantle:connected_4_angle", "x": -90, "y": 90 },
+        "connected_down=true,connected_east=true,connected_north=true,connected_south=false,connected_up=false,connected_west=true": { "model": "mantle:connected_4_angle", "x": -270, "y": -270 },
+
+        "connected_down=true,connected_east=true,connected_north=true,connected_south=true,connected_up=false,connected_west=true": { "model": "mantle:connected_4_cross" },
+        "connected_down=true,connected_east=true,connected_north=false,connected_south=true,connected_up=true,connected_west=true": { "model": "mantle:connected_4_cross" },
+        "connected_down=true,connected_east=false,connected_north=true,connected_south=true,connected_up=true,connected_west=true": { "model": "mantle:connected_4_cross" },
+        "connected_down=true,connected_east=true,connected_north=true,connected_south=true,connected_up=true,connected_west=false": { "model": "mantle:connected_4_cross" },
+        "connected_down=true,connected_east=true,connected_north=true,connected_south=false,connected_up=true,connected_west=true": { "model": "mantle:connected_4_cross" },
+        "connected_down=false,connected_east=true,connected_north=true,connected_south=true,connected_up=true,connected_west=true": { "model": "mantle:connected_4_cross" },
+
+        "connected_down=true,connected_east=true,connected_north=true,connected_south=true,connected_up=true,connected_west=true": { "model": "mantle:connected_4_cross" }
+	}
+}

--- a/src/main/resources/assets/mantle/models/block/connected_0.json
+++ b/src/main/resources/assets/mantle/models/block/connected_0.json
@@ -1,0 +1,13 @@
+{
+    "__comment": "The model for a block that is not being connected to on any angle.",
+    "parent": "mantle:block/tinted_cube",
+    "textures": {
+		"particle": "#normal",
+        "down": "#normal",
+		"up": "#normal",
+		"north": "#normal",
+		"south": "#normal",
+		"west": "#normal",
+		"east": "#normal"
+    }
+}

--- a/src/main/resources/assets/mantle/models/block/connected_1.json
+++ b/src/main/resources/assets/mantle/models/block/connected_1.json
@@ -1,0 +1,13 @@
+{
+    "__comment": "Model for when only one side is connected.",
+	"parent": "mantle:block/tinted_cube",
+    "textures": {
+		"particle": "#normal",
+        "down": "#normal",
+		"up": "#udlr",
+		"north": "#u",
+		"south": "#u",
+		"west": "#u",
+		"east": "#u"
+    }
+}

--- a/src/main/resources/assets/mantle/models/block/connected_2.json
+++ b/src/main/resources/assets/mantle/models/block/connected_2.json
@@ -1,0 +1,13 @@
+{
+    "__comment": "Model for when two sides are connected.",
+	"parent": "mantle:block/tinted_cube",
+    "textures": {
+		"particle": "#normal",
+        "down": "#udlr",
+		"up": "#udlr",
+		"north": "#ud",
+		"south": "#ud",
+		"west": "#ud",
+		"east": "#ud"
+    }
+}

--- a/src/main/resources/assets/mantle/models/block/connected_2_angle.json
+++ b/src/main/resources/assets/mantle/models/block/connected_2_angle.json
@@ -1,0 +1,13 @@
+{
+    "__comment": "Model for when two adgacent sides are connected.",
+	"parent": "mantle:block/tinted_cube",
+    "textures": {
+		"particle": "#normal",
+        "down": "#r",
+		"up": "#udlr",
+		"north": "#ul",
+		"south": "#ur",
+		"west": "#u",
+		"east": "#udlr"
+    }
+}

--- a/src/main/resources/assets/mantle/models/block/connected_3_T1.json
+++ b/src/main/resources/assets/mantle/models/block/connected_3_T1.json
@@ -1,0 +1,13 @@
+{
+    "__comment": "Model for when three adjacent connected sides are a T shape.",
+	"parent": "mantle:block/tinted_cube",
+    "textures": {
+		"particle": "#normal",
+        "down": "#udlr",
+		"up": "#udlr",
+		"north": "#udr",
+		"south": "#udl",
+		"west": "#udlr",
+		"east": "#ud"
+    }
+}

--- a/src/main/resources/assets/mantle/models/block/connected_3_T2.json
+++ b/src/main/resources/assets/mantle/models/block/connected_3_T2.json
@@ -1,0 +1,13 @@
+{
+    "__comment": "Model for when three adjacent sides connected sides in a T shape.",
+	"parent": "mantle:block/tinted_cube",
+    "textures": {
+		"particle": "#normal",
+        "down": "#lr",
+		"up": "#udlr",
+		"north": "#ulr",
+		"south": "#ulr",
+		"west": "#udlr",
+		"east": "#udlr"
+    }
+}

--- a/src/main/resources/assets/mantle/models/block/connected_3_angle.json
+++ b/src/main/resources/assets/mantle/models/block/connected_3_angle.json
@@ -1,0 +1,13 @@
+{
+    "__comment": "Model for when three adjacent sides are connected.",
+	"parent": "mantle:block/tinted_cube",
+    "textures": {
+		"particle": "#normal",
+        "down": "#ur",
+		"up": "#udlr",
+		"north": "#ul",
+		"south": "#udlr",
+		"west": "#ur",
+		"east": "#udlr"
+    }
+}

--- a/src/main/resources/assets/mantle/models/block/connected_4_angle.json
+++ b/src/main/resources/assets/mantle/models/block/connected_4_angle.json
@@ -1,0 +1,13 @@
+{
+    "__comment": "Model for when four connected sides at an angle.",
+	"parent": "mantle:block/tinted_cube",
+    "textures": {
+		"particle": "#normal",
+        "down": "#udlr",
+		"up": "#udlr",
+		"north": "#udlr",
+		"south": "#udl",
+		"west": "#udlr",
+		"east": "#udr"
+    }
+}

--- a/src/main/resources/assets/mantle/models/block/connected_4_cross.json
+++ b/src/main/resources/assets/mantle/models/block/connected_4_cross.json
@@ -1,0 +1,13 @@
+{
+    "__comment": "Model file for four or more connected sides in a cross shape.",
+	"parent": "mantle:block/tinted_cube",
+    "textures": {
+		"particle": "#normal",
+        "down": "#udlr",
+		"up": "#udlr",
+		"north": "#udlr",
+		"south": "#udlr",
+		"west": "#udlr",
+		"east": "#udlr"
+    }
+}

--- a/src/main/resources/assets/mantle/models/block/tinted_cube.json
+++ b/src/main/resources/assets/mantle/models/block/tinted_cube.json
@@ -1,0 +1,16 @@
+{
+    "parent": "block/block",
+    "elements": [
+        {   "from": [ 0, 0, 0 ],
+            "to": [ 16, 16, 16 ],
+            "faces": {
+                "down":  { "texture": "#down",  "cullface": "down",  "tintindex": 0 },
+                "up":    { "texture": "#up",    "cullface": "up",    "tintindex": 0 },
+                "north": { "texture": "#north", "cullface": "north", "tintindex": 0 },
+                "south": { "texture": "#south", "cullface": "south", "tintindex": 0 },
+                "west":  { "texture": "#west",  "cullface": "west",  "tintindex": 0 },
+                "east":  { "texture": "#east",  "cullface": "east",  "tintindex": 0 }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Only adds "full" connected textures without diagonals, no horizontal or alike. All the models are done using a Forge blockstate for simplicity, so copying the example Blockstate and changing the textures is the easiest way to add a model

This is based off a [tutorial by Darkhax](http://tutorials.darkhax.net/connected-block-textures.html), though with a few things modified to make it easier for extending and to support adding via EnumBlocks.

Also contains a null check to fix #63, since it was requested by boni.