### PR TITLE
Added two helper classes for trading with villagers

### DIFF
--- a/src/main/java/slimeknights/mantle/util/TradeGeneric.java
+++ b/src/main/java/slimeknights/mantle/util/TradeGeneric.java
@@ -1,0 +1,151 @@
+package slimeknights.mantle.util;
+
+import java.util.Random;
+
+import javax.annotation.Nonnull;
+import net.minecraft.entity.IMerchant;
+import net.minecraft.entity.passive.EntityVillager;
+import net.minecraft.entity.passive.EntityVillager.PriceInfo;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraft.village.MerchantRecipe;
+import net.minecraft.village.MerchantRecipeList;
+
+public class TradeGeneric implements EntityVillager.ITradeList {
+  private ItemStack input, input2, output;
+  private PriceInfo inputPrice, input2Price, outputPrice;
+
+  /**
+   * Creates a new trade of two input stacks for an output stack
+   *
+   * @param input        First input itemstack
+   * @param inputPrice   Random stack size range for first input
+   * @param input2       Second input itemstack
+   * @param input2Price  Random stack size range for second input
+   * @param output       Output itemstack
+   * @param outputPrice  Random stack size range for output
+   */
+  public TradeGeneric(ItemStack input, PriceInfo inputPrice, ItemStack input2, PriceInfo input2Price,
+      ItemStack output, PriceInfo outputPrice) {
+
+    this.input = input;
+    this.inputPrice = inputPrice;
+
+    this.input2 = input2;
+    this.input2Price = input2Price;
+
+    this.output = output;
+    this.outputPrice = outputPrice;
+  }
+
+  /**
+   * Creates a new trade of an input stack for an output stack
+   *
+   * @param input        Input itemstack
+   * @param inputPrice   Random stack size range for input
+   * @param output       Output itemstack
+   * @param outputPrice  Random stack size range for output
+   */
+  public TradeGeneric(ItemStack input, PriceInfo inputPrice, ItemStack output, PriceInfo outputPrice) {
+    this(input, inputPrice, ItemStack.EMPTY, null, output, outputPrice);
+  }
+
+  /**
+   * Creates a new trade with one input for emeralds
+   *
+   * @param input        Input itemstack
+   * @param inputPrice   Random stack size range for input
+   * @param outputPrice  Random range for output emerald
+   */
+  public TradeGeneric(ItemStack input, PriceInfo inputPrice, PriceInfo outputPrice) {
+    this(input, inputPrice, ItemStack.EMPTY, null, ItemStack.EMPTY, outputPrice);
+  }
+
+  /**
+   * Creates a new trade of emeralds for an output stack
+   *
+   * @param inputPrice   Random stack size range for input
+   * @param output       Output itemstack
+   * @param outputPrice  Random range for output emerald
+   */
+  public TradeGeneric(PriceInfo inputPrice, ItemStack output, PriceInfo outputPrice) {
+    this(ItemStack.EMPTY, inputPrice, ItemStack.EMPTY, null, output, outputPrice);
+  }
+
+  /**
+   * Getter for the input stack
+   * @param random  random number access
+   * @return  A new instance of the input stack, or a stack containing an emerald if empty
+   */
+  @Nonnull
+  protected ItemStack getInput(Random random) {
+    if(input.isEmpty()) {
+      return new ItemStack(Items.EMERALD);
+    }
+
+    return input.copy();
+  }
+
+  /**
+   * Getter for the second input stack, returns a new instance
+   * @param random  random number access
+   * @return  A new instance of the second input stack, or nothing if empty
+   */
+  protected ItemStack getInput2(Random random) {
+    // no copy if empty
+    if(input2.isEmpty()) {
+      return ItemStack.EMPTY;
+    }
+    return input2.copy();
+  }
+
+  /**
+   * Getter for the output stack
+   * @param random  random number access
+   * @return  A new instance of the output stack, or a stack containing an emerald if null
+   */
+  @Nonnull
+  protected ItemStack getOutput(Random random) {
+    if(output.isEmpty()) {
+      return new ItemStack(Items.EMERALD);
+    }
+
+    return output.copy();
+  }
+
+  @Override
+  public void addMerchantRecipe(IMerchant merchant, MerchantRecipeList recipeList, Random random) {
+    ItemStack input = getInput(random);
+    ItemStack output = getOutput(random);
+
+    // set random counts
+    int size = 1;
+    if(inputPrice != null) {
+      size = inputPrice.getPrice(random);
+    }
+    input.setCount(size);
+
+    // set random counts
+    size = 1;
+    if(outputPrice != null) {
+      size = outputPrice.getPrice(random);
+    }
+    output.setCount(size);
+
+    // only modify second stack if it exists
+    ItemStack input2 = getInput2(random);
+    if(!input2.isEmpty()) {
+      // set the size for the second stack
+      size = 1;
+      // null means 1
+      if(input2Price != null) {
+        size = input2Price.getPrice(random);
+      }
+
+      input2.setCount(size);
+    }
+
+    // create the actual "recipe"
+    recipeList.add(new MerchantRecipe(input, input2, output));
+  }
+}

--- a/src/main/java/slimeknights/mantle/util/TradeRandom.java
+++ b/src/main/java/slimeknights/mantle/util/TradeRandom.java
@@ -1,0 +1,73 @@
+package slimeknights.mantle.util;
+
+import java.util.Random;
+
+import javax.annotation.Nonnull;
+
+import net.minecraft.entity.passive.EntityVillager.PriceInfo;
+import net.minecraft.item.ItemStack;
+
+public class TradeRandom extends TradeGeneric {
+
+  // data
+  private ItemStack[] inputs;
+  private ItemStack[] outputs;
+
+  /**
+   * Trade a randomly chosen item item from the list for another randomly chosen item
+   * @param inputs       List of inputs to randomly choose from
+   * @param inputPrice   Random stack size range for input
+   * @param outputs      List of outputs to randomly choose from
+   * @param outputPrice  Random stack size range for output
+   */
+  public TradeRandom(ItemStack[] inputs, PriceInfo inputPrice, ItemStack[] outputs, PriceInfo outputPrice) {
+    super(ItemStack.EMPTY, inputPrice, ItemStack.EMPTY, outputPrice);
+    this.inputs = inputs;
+    this.outputs = outputs;
+  }
+
+  /**
+   * Trade a randomly chosen item from the list for emeralds
+   * @param inputs       List of inputs to randomly choose from
+   * @param inputPrice   Random stack size range for input
+   * @param outputPrice  Random stack size range for output
+   */
+  public TradeRandom(ItemStack[] inputs, PriceInfo inputPrice, PriceInfo outputPrice) {
+    this(inputs, inputPrice, null, outputPrice);
+  }
+
+  /**
+   * Trade emeralds for a randomly chosen item from the list
+   * @param inputPrice   Random stack size range for input
+   * @param outputs      List of outputs to randomly choose from
+   * @param outputPrice  Random stack size range for output
+   */
+  public TradeRandom(PriceInfo inputPrice, ItemStack[] outputs, PriceInfo outputPrice) {
+    this(null, inputPrice, outputs, outputPrice);
+  }
+
+  @Override
+  @Nonnull
+  protected ItemStack getOutput(Random random) {
+    // array does not exist? return default
+    if(outputs == null) {
+      return super.getOutput(random);
+    }
+    // return a random stack from the list
+    int i = random.nextInt(outputs.length);
+    return outputs[i].copy();
+  }
+
+  @Override
+  @Nonnull
+  protected ItemStack getInput(Random random) {
+    // array does not exist? return default
+	if(inputs == null) {
+      return super.getInput(random);
+	}
+    // return a random stack from the list
+    int i = random.nextInt(inputs.length);
+    return inputs[i].copy();
+  }
+
+}


### PR DESCRIPTION
Vanilla only implements this for items instead of stacks. Methods provided allow adding a trade using two inputs for an output and a random input for a random output. Any of those can be null to default to emeralds (except the second input, where null makes it a single input trade)
