### PR TITLE
Fix JSON boolean representation of false

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -14,5 +14,5 @@
   "requiredMods": [],
   "dependencies": [],
   "dependants": [],
-  "useDependencyInformation": "false"
+  "useDependencyInformation": false
 }]


### PR DESCRIPTION
Not all JSON parsers transparently convert `"false"` to `false`