### PR TITLE
Improve exceptions thrown on module lifecycle events

### DIFF
--- a/src/main/java/slimeknights/mantle/pulsar/flightpath/Flightpath.java
+++ b/src/main/java/slimeknights/mantle/pulsar/flightpath/Flightpath.java
@@ -1,5 +1,6 @@
 package slimeknights.mantle.pulsar.flightpath;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -88,7 +89,15 @@ public class Flightpath {
                             m.setAccessible(true);
                             m.invoke(ent.getKey(), evt);
                             m.setAccessible(access);
+                        } catch(InvocationTargetException ex) {
+                            // thrown when a method throws an exception, so use that exception instead of the wrapper for a better stacktrace
+                            if(ex.getTargetException() instanceof Exception) {
+                                exceptionHandler.handle((Exception)ex.getTargetException());
+                            } else {
+                                exceptionHandler.handle(ex);
+                            }
                         } catch (Exception ex) {
+                            // all other exceptions, this means something when wrong with the reflection
                             exceptionHandler.handle(ex);
                         }
                     }

--- a/src/main/java/slimeknights/mantle/pulsar/internal/BusExceptionHandler.java
+++ b/src/main/java/slimeknights/mantle/pulsar/internal/BusExceptionHandler.java
@@ -27,6 +27,10 @@ public final class BusExceptionHandler implements IExceptionHandler {
     @Override
     public void handle(Exception ex) {
         this.logger.error("Exception caught from a pulse on flightpath for mod ID " + id + ": ", ex);
+        // if its a runtime exception, we can just throw it as is
+        if(ex instanceof RuntimeException) {
+          throw (RuntimeException)ex;
+        }
         throw new Error(ex);
     }
 


### PR DESCRIPTION
This removes the redundant wrapper around all exceptions thrown by the lifecycle events. Basically, when an exception is thrown by a method called by reflection, Java wraps it in InvocationTargetException, which appears in the stack trace despite providing no useful information

PR instead of merging directly to give someone else a chance to review this.