### PR TITLE
Fix health bar to work with Forge left_height

### DIFF
--- a/src/main/java/slimeknights/mantle/client/ExtraHeartRenderHandler.java
+++ b/src/main/java/slimeknights/mantle/client/ExtraHeartRenderHandler.java
@@ -61,7 +61,7 @@ public class ExtraHeartRenderHandler {
     EntityPlayer player = (EntityPlayer)this.mc.getRenderViewEntity();
     
     // extra setup stuff from us
-    left_height = 39;
+    left_height = GuiIngameForge.left_height;
     ScaledResolution resolution = event.getResolution();
     width = resolution.getScaledWidth();
     height = resolution.getScaledHeight();


### PR DESCRIPTION
Single commit PR, just changes the initial value of (local) `left_height` to the global `GuiIngameForge.left_height` so the bar renders at the correct height for compat with other mods. See #114  for an example.