### PR TITLE
Catch errors resulting from git not being on the system-wide PATH

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,13 +54,17 @@ targetCompatibility = 1.8
 
 // sets version to the slimeKnights version format
 task buildInfo {
-    def cmd = "git rev-parse --short HEAD"
-    def proc = cmd.execute()
-    proc.waitFor()
-    if (proc.exitValue() == 0) {
-        ext.revision = proc.text.trim()
-    } else {
-        ext.revision = "GITBORK"
+    try {
+        def cmd = "git rev-parse --short HEAD"
+        def proc = cmd.execute()
+        proc.waitFor()
+        if (proc.exitValue() == 0) {
+            ext.revision = proc.text.trim()
+        } else {
+            ext.revision = "GITBORK"
+        }
+    } catch(all) {
+        ext.revision = "gitgud"
     }
 
     if (System.getenv().BUILD_NUMBER != null) {


### PR DESCRIPTION
Code copied over from Tinker's Construct.