### PR TITLE
Clear tooltip before adding a new one

### DIFF
--- a/src/main/java/slimeknights/mantle/client/gui/book/TextDataRenderer.java
+++ b/src/main/java/slimeknights/mantle/client/gui/book/TextDataRenderer.java
@@ -138,6 +138,7 @@ public class TextDataRenderer {
         drawGradientRect(mouseX, mouseY, mouseX + 5, mouseY + 5, 0xFFFF00FF, 0xFFFFFF00);*/
 
         if((mouseX >= box1X && mouseX <= box1W && mouseY >= box1Y && mouseY <= box1H && box1X != box1W && box1Y != box1H) || (mouseX >= box2X && mouseX <= box2W && mouseY >= box2Y && mouseY <= box2H && box2X != box2W && box2Y != box2H) || (mouseX >= box3X && mouseX <= box3W && mouseY >= box3Y && mouseY <= box3H && box3X != box3W && box1Y != box3H)) {
+          tooltip.clear();
           tooltip.addAll(Arrays.asList(item.tooltip));
         }
       }


### PR DESCRIPTION
This prevents multiple tooltip texts from showing up in a single tooltip and makes the behaviour consistent with the way item.action is handled.

![image](https://user-images.githubusercontent.com/963797/68552732-9db88d80-041a-11ea-977f-483aa89ea2ba.png)