### PR TITLE
recipes: move BaseRecipeProvider from TConstruct

### DIFF
--- a/src/main/java/slimeknights/mantle/recipe/data/BaseRecipeProvider.java
+++ b/src/main/java/slimeknights/mantle/recipe/data/BaseRecipeProvider.java
@@ -1,0 +1,344 @@
+package slimeknights.mantle.recipe.data;
+
+import net.minecraft.advancements.ICriterionInstance;
+import net.minecraft.data.CookingRecipeBuilder;
+import net.minecraft.data.DataGenerator;
+import net.minecraft.data.IFinishedRecipe;
+import net.minecraft.data.RecipeProvider;
+import net.minecraft.data.ShapedRecipeBuilder;
+import net.minecraft.data.ShapelessRecipeBuilder;
+import net.minecraft.data.SingleItemRecipeBuilder;
+import net.minecraft.item.Item;
+import net.minecraft.item.crafting.IRecipeSerializer;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.tags.ITag;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.util.IItemProvider;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.crafting.conditions.ICondition;
+import net.minecraftforge.common.crafting.conditions.IConditionBuilder;
+import net.minecraftforge.common.crafting.conditions.NotCondition;
+import net.minecraftforge.common.crafting.conditions.TagEmptyCondition;
+import net.minecraftforge.registries.IForgeRegistryEntry;
+import slimeknights.mantle.registration.object.BuildingBlockObject;
+import slimeknights.mantle.registration.object.MetalItemObject;
+import slimeknights.mantle.registration.object.WallBuildingBlockObject;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Shared logic for each module's recipe provider
+ */
+public abstract class BaseRecipeProvider extends RecipeProvider implements IConditionBuilder {
+  public static String modID;
+
+  public BaseRecipeProvider(DataGenerator generator, String modID) {
+    super(generator);
+    this.modID = modID;
+  }
+
+  @Override
+  protected abstract void registerRecipes(Consumer<IFinishedRecipe> consumer);
+
+  @Override
+  public abstract String getName();
+
+
+  /* Location helpers */
+
+  /**
+   * Gets a resource location for Tinkers
+   * @param id  Location path
+   * @return  Location for Tinkers
+   */
+  protected static ResourceLocation location(String id) {
+    return new ResourceLocation(modID, id);
+  }
+
+  /**
+   * Gets a resource location string for Tinkers
+   * @param id  Location path
+   * @return  Location for Tinkers
+   */
+  protected static String locationString(String id) {
+    return modID + ":" + id;
+  }
+
+  /**
+   * Prefixes the resource location path with the given value
+   * @param item    Item registry name to use
+   * @param prefix  Prefix value
+   * @return  Resource location path
+   */
+  protected static ResourceLocation wrap(IItemProvider item, String prefix, String suffix) {
+    ResourceLocation loc = Objects.requireNonNull(item.asItem().getRegistryName());
+    return location(prefix + loc.getPath() + suffix);
+  }
+
+  /**
+   * Prefixes the resource location path with the given value
+   * @param entry    Item registry name to use
+   * @param prefix  Prefix value
+   * @return  Resource location path
+   */
+  protected static ResourceLocation wrapR(Supplier<? extends IForgeRegistryEntry<?>> entry, String prefix, String suffix) {
+    ResourceLocation loc = Objects.requireNonNull(entry.get().getRegistryName());
+    return location(prefix + loc.getPath() + suffix);
+  }
+
+  /**
+   * Prefixes the resource location path with the given value
+   * @param item    Item registry name to use
+   * @param prefix  Prefix value
+   * @return  Resource location path
+   */
+  protected static ResourceLocation prefix(IItemProvider item, String prefix) {
+    ResourceLocation loc = Objects.requireNonNull(item.asItem().getRegistryName());
+    return location(prefix + loc.getPath());
+  }
+
+  /**
+   * Prefixes the resource location path with the given value
+   * @param entry   Entry registry name to use
+   * @param prefix  Prefix value
+   * @return  Resource location path
+   */
+  protected static ResourceLocation prefixR(Supplier<? extends IForgeRegistryEntry<?>> entry, String prefix) {
+    ResourceLocation loc = Objects.requireNonNull(entry.get().getRegistryName());
+    return location(prefix + loc.getPath());
+  }
+
+  /**
+   * Prefixes the resource location path with the given value
+   * @param entry   Entry registry name to use
+   * @param prefix  Prefix value
+   * @return  Resource location path
+   */
+  protected static ResourceLocation prefixR(IForgeRegistryEntry<?> entry, String prefix) {
+    ResourceLocation loc = Objects.requireNonNull(entry.getRegistryName());
+    return location(prefix + loc.getPath());
+  }
+
+  /**
+   * Gets a tag by name
+   * @param modId  Mod ID for tag
+   * @param name   Tag name
+   * @return  Tag instance
+   */
+  protected static ITag<Item> getTag(String modId, String name) {
+    return ItemTags.makeWrapperTag(modId + ":" + name);
+  }
+
+
+  /* Recipe helpers */
+
+  /**
+   * Registers generic building block recipes for slabs and stairs
+   * @param consumer  Recipe consumer
+   * @param building  Building object instance
+   */
+  protected void registerSlabStair(Consumer<IFinishedRecipe> consumer, BuildingBlockObject building, String folder, boolean addStonecutter) {
+    Item item = building.asItem();
+    ICriterionInstance hasBlock = hasItem(item);
+    // slab
+    IItemProvider slab = building.getSlab();
+    ShapedRecipeBuilder.shapedRecipe(slab, 6)
+                       .key('B', item)
+                       .patternLine("BBB")
+                       .addCriterion("has_item", hasBlock)
+                       .setGroup(Objects.requireNonNull(slab.asItem().getRegistryName()).toString())
+                       .build(consumer, wrap(item, folder, "_slab"));
+    // stairs
+    IItemProvider stairs = building.getStairs();
+    ShapedRecipeBuilder.shapedRecipe(stairs, 4)
+                       .key('B', item)
+                       .patternLine("B  ")
+                       .patternLine("BB ")
+                       .patternLine("BBB")
+                       .addCriterion("has_item", hasBlock)
+                       .setGroup(Objects.requireNonNull(stairs.asItem().getRegistryName()).toString())
+                       .build(consumer, wrap(item, folder, "_stairs"));
+
+    // only add stonecutter if relevant
+    if (addStonecutter) {
+      Ingredient ingredient = Ingredient.fromItems(item);
+      SingleItemRecipeBuilder.stonecuttingRecipe(ingredient, slab, 2)
+                             .addCriterion("has_item", hasBlock)
+                             .build(consumer, wrap(item, folder, "_slab_stonecutter"));
+      SingleItemRecipeBuilder.stonecuttingRecipe(ingredient, stairs)
+                             .addCriterion("has_item", hasBlock)
+                             .build(consumer, wrap(item, folder, "_stairs_stonecutter"));
+    }
+  }
+
+  /**
+   * Registers generic building block recipes for slabs, stairs, and walls
+   * @param consumer  Recipe consumer
+   * @param building  Building object instance
+   */
+  protected void registerSlabStairWall(Consumer<IFinishedRecipe> consumer, WallBuildingBlockObject building, String folder, boolean addStonecutter) {
+    registerSlabStair(consumer, building, folder, addStonecutter);
+    // wall
+    Item item = building.asItem();
+    ICriterionInstance hasBlock = hasItem(item);
+    IItemProvider wall = building.getWall();
+    ShapedRecipeBuilder.shapedRecipe(wall, 4)
+                       .key('B', item)
+                       .patternLine("BBB")
+                       .patternLine("BBB")
+                       .addCriterion("has_item", hasBlock)
+                       .setGroup(Objects.requireNonNull(wall.asItem().getRegistryName()).toString())
+                       .build(consumer, wrap(item, folder, "_wall"));
+    // only add stonecutter if relevant
+    if (addStonecutter) {
+      Ingredient ingredient = Ingredient.fromItems(item);
+      SingleItemRecipeBuilder.stonecuttingRecipe(ingredient, wall)
+                             .addCriterion("has_item", hasBlock)
+                             .build(consumer, wrap(item, folder, "_wall_stonecutter"));
+    }
+  }
+
+  /**
+   * Registers a recipe packing a small item into a large one
+   * @param consumer   Recipe consumer
+   * @param large      Large item
+   * @param small      Small item
+   * @param largeName  Large name
+   * @param smallName  Small name
+   * @param folder     Recipe folder
+   */
+  protected void registerPackingRecipe(Consumer<IFinishedRecipe> consumer, String largeName, IItemProvider large, String smallName, IItemProvider small, String folder) {
+    // ingot to block
+    ShapedRecipeBuilder.shapedRecipe(large)
+                       .key('#', small)
+                       .patternLine("###")
+                       .patternLine("###")
+                       .patternLine("###")
+                       .addCriterion("has_item", hasItem(small))
+                       .setGroup(Objects.requireNonNull(large.asItem().getRegistryName()).toString())
+                       .build(consumer, wrap(large, folder, String.format("_from_%ss", smallName)));
+    // block to ingot
+    ShapelessRecipeBuilder.shapelessRecipe(small, 9)
+                          .addIngredient(large)
+                          .addCriterion("has_item", hasItem(large))
+                          .setGroup(Objects.requireNonNull(small.asItem().getRegistryName()).toString())
+                          .build(consumer, wrap(small, folder, String.format("_from_%s", largeName)));
+  }
+
+  /**
+   * Registers a recipe packing a small item into a large one
+   * @param consumer   Recipe consumer
+   * @param largeItem  Large item
+   * @param smallItem  Small item
+   * @param smallTag   Tag for small item
+   * @param largeName  Large name
+   * @param smallName  Small name
+   * @param folder     Recipe folder
+   */
+  protected void registerPackingRecipe(Consumer<IFinishedRecipe> consumer, String largeName, IItemProvider largeItem, String smallName, IItemProvider smallItem, ITag<Item> smallTag, String folder) {
+    // ingot to block
+    // note our item is in the center, any mod allowed around the edges
+    ShapedRecipeBuilder.shapedRecipe(largeItem)
+                       .key('#', smallTag)
+                       .key('*', smallItem)
+                       .patternLine("###")
+                       .patternLine("#*#")
+                       .patternLine("###")
+                       .addCriterion("has_item", hasItem(smallItem))
+                       .setGroup(Objects.requireNonNull(largeItem.asItem().getRegistryName()).toString())
+                       .build(consumer, wrap(largeItem, folder, String.format("_from_%ss", smallName)));
+    // block to ingot
+    ShapelessRecipeBuilder.shapelessRecipe(smallItem, 9)
+                          .addIngredient(largeItem)
+                          .addCriterion("has_item", hasItem(largeItem))
+                          .setGroup(Objects.requireNonNull(smallItem.asItem().getRegistryName()).toString())
+                          .build(consumer, wrap(smallItem, folder, String.format("_from_%s", largeName)));
+  }
+
+  /**
+   * Adds a campfire cooking recipe
+   * @param consumer    Recipe consumer
+   * @param input       Recipe input
+   * @param output      Recipe output
+   * @param experience  Experience for the recipe
+   * @param folder      Folder to store the recipe
+   */
+  protected void addCampfireCooking(Consumer<IFinishedRecipe> consumer, IItemProvider input, IItemProvider output, float experience, String folder) {
+    CookingRecipeBuilder.cookingRecipe(Ingredient.fromItems(input), output, experience, 600, IRecipeSerializer.CAMPFIRE_COOKING)
+            .addCriterion("has_item", hasItem(input))
+            .build(consumer, wrap(output, folder, "_campfire"));
+  }
+
+  /**
+   * Adds a recipe to the campfire, furnace, and smoker
+   * @param consumer    Recipe consumer
+   * @param input       Recipe input
+   * @param output      Recipe output
+   * @param experience  Experience for the recipe
+   * @param folder      Folder to store the recipe
+   */
+  protected void addFoodCooking(Consumer<IFinishedRecipe> consumer, IItemProvider input, IItemProvider output, float experience, String folder) {
+    addCampfireCooking(consumer, input, output, experience, folder);
+    // furnace is 200 ticks
+    ICriterionInstance criteria = hasItem(input);
+    CookingRecipeBuilder.smeltingRecipe(Ingredient.fromItems(input), output, experience, 200)
+            .addCriterion("has_item", criteria)
+            .build(consumer, wrap(output, folder, "_furnace"));
+    // smoker 100 ticks
+    CookingRecipeBuilder.cookingRecipe(Ingredient.fromItems(input), output, experience, 100, IRecipeSerializer.SMOKING)
+            .addCriterion("has_item", criteria)
+            .build(consumer, wrap(output, folder, "_smoker"));
+  }
+
+  /**
+   * Adds recipes to convert a block to ingot, ingot to block, and for nuggets
+   * @param consumer  Recipe consumer
+   * @param metal     Metal object
+   * @param folder    Folder for recipes
+   */
+  protected void registerMineralRecipes(Consumer<IFinishedRecipe> consumer, MetalItemObject metal, String folder) {
+    IItemProvider ingot = metal.getIngot();
+    registerPackingRecipe(consumer, "block", metal.get(), "ingot", ingot, metal.getIngotTag(), folder);
+    registerPackingRecipe(consumer, "ingot", ingot, "nugget", metal.getNugget(), metal.getNuggetTag(), folder);
+  }
+
+  /* conditions */
+
+  /**
+   * Creates a consumer instance with the added conditions
+   * @param consumer    Base consumer
+   * @param conditions  Extra conditions
+   * @return  Wrapped consumer
+   */
+  protected static Consumer<IFinishedRecipe> withCondition(Consumer<IFinishedRecipe> consumer, ICondition... conditions) {
+    ConsumerWrapperBuilder builder = ConsumerWrapperBuilder.wrap();
+    for (ICondition condition : conditions) {
+      builder.addCondition(condition);
+    }
+    return builder.build(consumer);
+  }
+
+  /**
+   * Creates a condition for a tag existing
+   * @param name  Forge tag name
+   * @return  Condition for tag existing
+   */
+  protected static ICondition tagCondition(String name) {
+    return new NotCondition(new TagEmptyCondition("forge", name));
+  }
+
+  // Forge constructor is private, not sure if there is a public place for this
+  protected static class CompoundIngredient extends net.minecraftforge.common.crafting.CompoundIngredient {
+    public CompoundIngredient(List<Ingredient> children) {
+      super(children);
+    }
+
+    public CompoundIngredient(Ingredient... children) {
+      this(Arrays.asList(children));
+    }
+  }
+}

--- a/src/main/java/slimeknights/mantle/registration/deferred/BlockDeferredRegister.java
+++ b/src/main/java/slimeknights/mantle/registration/deferred/BlockDeferredRegister.java
@@ -17,6 +17,7 @@ import slimeknights.mantle.registration.object.BuildingBlockObject;
 import slimeknights.mantle.registration.object.EnumObject;
 import slimeknights.mantle.registration.object.FenceBuildingBlockObject;
 import slimeknights.mantle.registration.object.ItemObject;
+import slimeknights.mantle.registration.object.MetalItemObject;
 import slimeknights.mantle.registration.object.WallBuildingBlockObject;
 
 import java.util.function.Function;
@@ -200,5 +201,59 @@ public class BlockDeferredRegister extends DeferredRegisterWrapper<Block> {
   public <T extends Enum<T> & IStringSerializable, B extends Block> EnumObject<T,B> registerEnum(
       String name, T[] values, Function<T,? extends B> mapper, Function<? super B, ? extends BlockItem> item) {
     return registerEnum(name, values, (fullName, value) -> register(fullName, () -> mapper.apply(value), item));
+  }
+
+  /**
+   * Creates a new metal item object
+   * @param name           Metal name
+   * @param tagName        Name to use for tags for this block
+   * @param blockSupplier  Supplier for the block
+   * @param blockItem      Block item
+   * @param itemProps      Properties for the item
+   * @return  Metal item object
+   */
+  public MetalItemObject registerMetal(String name, String tagName, Supplier<Block> blockSupplier, Function<Block,? extends BlockItem> blockItem, Item.Properties itemProps) {
+    ItemObject<Block> block = register(name + "_block", blockSupplier, blockItem);
+    Supplier<Item> itemSupplier = () -> new Item(itemProps);
+    RegistryObject<Item> ingot = itemRegister.register(name + "_ingot", itemSupplier);
+    RegistryObject<Item> nugget = itemRegister.register(name + "_nugget", itemSupplier);
+    return new MetalItemObject(tagName, block, ingot, nugget);
+  }
+
+  /**
+   * Creates a new metal item object
+   * @param name           Metal name
+   * @param blockSupplier  Supplier for the block
+   * @param blockItem      Block item
+   * @param itemProps      Properties for the item
+   * @return  Metal item object
+   */
+  public MetalItemObject registerMetal(String name, Supplier<Block> blockSupplier, Function<Block,? extends BlockItem> blockItem, Item.Properties itemProps) {
+    return registerMetal(name, name, blockSupplier, blockItem, itemProps);
+  }
+
+  /**
+   * Creates a new metal item object
+   * @param name        Metal name
+   * @param tagName     Name to use for tags for this block
+   * @param blockProps  Properties for the block
+   * @param blockItem   Block item
+   * @param itemProps   Properties for the item
+   * @return  Metal item object
+   */
+  public MetalItemObject registerMetal(String name, String tagName, AbstractBlock.Properties blockProps, Function<Block,? extends BlockItem> blockItem, Item.Properties itemProps) {
+    return registerMetal(name, tagName, () -> new Block(blockProps), blockItem, itemProps);
+  }
+
+  /**
+   * Creates a new metal item object
+   * @param name        Metal name
+   * @param blockProps  Properties for the block
+   * @param blockItem   Block item
+   * @param itemProps   Properties for the item
+   * @return  Metal item object
+   */
+  public MetalItemObject registerMetal(String name, AbstractBlock.Properties blockProps, Function<Block,? extends BlockItem> blockItem, Item.Properties itemProps) {
+    return registerMetal(name, name, blockProps, blockItem, itemProps);
   }
 }

--- a/src/main/java/slimeknights/mantle/registration/object/MetalItemObject.java
+++ b/src/main/java/slimeknights/mantle/registration/object/MetalItemObject.java
@@ -1,0 +1,54 @@
+package slimeknights.mantle.registration.object;
+
+import lombok.Getter;
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.Tags.IOptionalNamedTag;
+
+import java.util.function.Supplier;
+
+/** Object wrapper containing ingots, nuggets, and blocks */
+public class MetalItemObject extends ItemObject<Block> {
+  private final Supplier<? extends Item> ingot;
+  private final Supplier<? extends Item> nugget;
+  @Getter
+  private final IOptionalNamedTag<Block> blockTag;
+  @Getter
+  private final IOptionalNamedTag<Item> blockItemTag;
+  @Getter
+  private final IOptionalNamedTag<Item> ingotTag;
+  @Getter
+  private final IOptionalNamedTag<Item> nuggetTag;
+
+  public MetalItemObject(String tagName, ItemObject<? extends Block> block, Supplier<? extends Item> ingot, Supplier<? extends Item> nugget) {
+    super(block);
+    this.ingot = ingot;
+    this.nugget = nugget;
+    this.blockTag = BlockTags.createOptional(new ResourceLocation("forge", "storage_blocks/" + tagName));
+    this.blockItemTag = getTag("storage_blocks/" + tagName);
+    this.ingotTag = getTag("ingots/" + tagName);
+    this.nuggetTag = getTag("nuggets/" + tagName);
+  }
+
+  /** Gets the ingot for this object */
+  public Item getIngot() {
+    return ingot.get();
+  }
+
+  /** Gets the ingot for this object */
+  public Item getNugget() {
+    return nugget.get();
+  }
+
+  /**
+   * Creates a tag for a resource
+   * @param name  Tag name
+   * @return  Tag
+   */
+  private static IOptionalNamedTag<Item> getTag(String name) {
+    return ItemTags.createOptional(new ResourceLocation("forge", name));
+  }
+}


### PR DESCRIPTION
Strikes me as useful for mods in general, even if they are not
TConstruct addons.

Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>