### PR TITLE
fix auto UV on fluid quads

### DIFF
--- a/src/main/java/slimeknights/mantle/client/render/FluidRenderer.java
+++ b/src/main/java/slimeknights/mantle/client/render/FluidRenderer.java
@@ -76,18 +76,30 @@ public class FluidRenderer {
     float x2 = to.getX(), y2 = to.getY(), z2 = to.getZ();
     // choose UV based on opposite two axis
     float u1, u2, v1, v2;
-    switch (face.getAxis()) {
-      case Y:
+    switch (face) {
+      case DOWN:
       default:
         u1 = x1; u2 = x2;
         v1 = z2; v2 = z1;
         break;
-      case Z:
+      case UP:
+        u1 = x1; u2 = x2;
+        v1 = 1 - z1; v2 = 1 - z2;
+        break;
+      case NORTH:
+        u1 = 1 - x1; u2 = 1 - x2;
+        v1 = y1; v2 = y2;
+        break;
+      case SOUTH:
         u1 = x2; u2 = x1;
         v1 = y1; v2 = y2;
         break;
-      case X:
+      case WEST:
         u1 = z2; u2 = z1;
+        v1 = y1; v2 = y2;
+        break;
+      case EAST:
+        u1 = 1 - z1; u2 = 1 - z2;
         v1 = y1; v2 = y2;
         break;
     }


### PR DESCRIPTION
As discussed on discord, some blocks from tinkers construct that use the mantle:fluids model loader have wrong UVs on some faces, this PR fixes the UVs on the up, north and east faces.

This is the resource pack I used to test these changes
[fluid model test.zip](https://github.com/SlimeKnights/Mantle/files/7775163/fluid.model.test.zip)
It changes the molten magma texture to the minecraft debug texture and changes the faucet model to a test model made up of a 2x2x2 cube of 8 smaller cubes.

The liquid in a faucet facing south should look identical to the liquid in a tank, the debug texture should always look like this:
![image](https://user-images.githubusercontent.com/10962454/147372891-4e3cfafa-0ea3-44a7-85e8-bdc34340862c.png)
