### PR TITLE
fix broken fluid UVs with negative coordinates

### DIFF
--- a/src/main/java/slimeknights/mantle/client/render/FluidRenderer.java
+++ b/src/main/java/slimeknights/mantle/client/render/FluidRenderer.java
@@ -76,30 +76,18 @@ public class FluidRenderer {
     float x2 = to.getX(), y2 = to.getY(), z2 = to.getZ();
     // choose UV based on opposite two axis
     float u1, u2, v1, v2;
-    switch (face) {
-      case DOWN:
+    switch (face.getAxis()) {
+      case Y:
       default:
         u1 = x1; u2 = x2;
         v1 = z2; v2 = z1;
         break;
-      case UP:
-        u1 = x1; u2 = x2;
-        v1 = 1 - z1; v2 = 1 - z2;
-        break;
-      case NORTH:
-        u1 = 1 - x1; u2 = 1 - x2;
-        v1 = y1; v2 = y2;
-        break;
-      case SOUTH:
+      case Z:
         u1 = x2; u2 = x1;
         v1 = y1; v2 = y2;
         break;
-      case WEST:
+      case X:
         u1 = z2; u2 = z1;
-        v1 = y1; v2 = y2;
-        break;
-      case EAST:
-        u1 = 1 - z1; u2 = 1 - z2;
         v1 = y1; v2 = y2;
         break;
     }
@@ -121,6 +109,22 @@ public class FluidRenderer {
       if (v1 == 0) v1 = 1;
     } else {
       if (v2 == 0) v2 = 1;
+    }
+
+    switch (face) {
+      default:
+        break;
+      case UP:
+        float temp = v1;
+        v1 = 1f - v2;
+        v2 = 1f - temp;
+        break;
+      case NORTH:
+        u1 = 1f - u1; u2 = 1f - u2;
+        break;
+      case EAST:
+        u1 = 1f - u1; u2 = 1f - u2;
+        break;
     }
 
     // flip V when relevant

--- a/src/main/java/slimeknights/mantle/client/render/FluidRenderer.java
+++ b/src/main/java/slimeknights/mantle/client/render/FluidRenderer.java
@@ -76,18 +76,30 @@ public class FluidRenderer {
     float x2 = to.getX(), y2 = to.getY(), z2 = to.getZ();
     // choose UV based on opposite two axis
     float u1, u2, v1, v2;
-    switch (face.getAxis()) {
-      case Y:
+    switch (face) {
+      case DOWN:
       default:
         u1 = x1; u2 = x2;
         v1 = z2; v2 = z1;
         break;
-      case Z:
+      case UP:
+        u1 = x1; u2 = x2;
+        v1 = 1 - z1; v2 = 1 - z2;
+        break;
+      case NORTH:
+        u1 = 1 - x1; u2 = 1 - x2;
+        v1 = y1; v2 = y2;
+        break;
+      case SOUTH:
         u1 = x2; u2 = x1;
         v1 = y1; v2 = y2;
         break;
-      case X:
+      case WEST:
         u1 = z2; u2 = z1;
+        v1 = y1; v2 = y2;
+        break;
+      case EAST:
+        u1 = 1 - z1; u2 = 1 - z2;
         v1 = y1; v2 = y2;
         break;
     }


### PR DESCRIPTION
My previous pull request #172 introduced a bug with smelteries since they render fluid quads with negative coordinates (as seen in the screenshot), this pull request fixes that bug.
![2021-12-28_21 03 14](https://user-images.githubusercontent.com/10962454/147696201-71f653e9-7ded-457c-bbcb-892ea7728c1e.png)