### PR TITLE
Fix Mac Mouse Error

### DIFF
--- a/src/main/java/slimeknights/mantle/client/screen/book/BookScreen.java
+++ b/src/main/java/slimeknights/mantle/client/screen/book/BookScreen.java
@@ -535,12 +535,12 @@ public class BookScreen extends Screen {
 
   protected int getMouseX(boolean rightSide) {
     assert this.minecraft != null;
-    return (int) ((Minecraft.getInstance().mouseHandler.xpos() * this.width / this.minecraft.getWindow().getWidth() - this.leftOffset(rightSide)) / PAGE_SCALE);
+    return (int) ((Minecraft.getInstance().mouseHandler.xpos() * this.width / this.minecraft.getWindow().getScreenWidth() - this.leftOffset(rightSide)) / PAGE_SCALE);
   }
 
   protected int getMouseY() {
     assert this.minecraft != null;
-    return (int) ((Minecraft.getInstance().mouseHandler.ypos() * this.height / this.minecraft.getWindow().getHeight() - 1 - this.topOffset()) / PAGE_SCALE);
+    return (int) ((Minecraft.getInstance().mouseHandler.ypos() * this.height / this.minecraft.getWindow().getScreenHeight() - 1 - this.topOffset()) / PAGE_SCALE);
   }
 
   public int openPage(int page) {


### PR DESCRIPTION
This commit will fix the mouse hover tooltip detection error on Mac.

This commit should not break Windows, but further testing is needed to confirm.

This should work for 1.16.5 and 1.18.2 as well, though I commit on 1.18.1 for easier testing