### PR TITLE
Allow IngredientData to accept tags [1.19.2]

### DIFF
--- a/src/main/java/slimeknights/mantle/client/book/data/element/IngredientData.java
+++ b/src/main/java/slimeknights/mantle/client/book/data/element/IngredientData.java
@@ -142,8 +142,14 @@ public class IngredientData implements IDataElement {
         JsonPrimitive primitive = json.getAsJsonPrimitive();
 
         if(primitive.isString()) {
-          Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(primitive.getAsString()));
-          return SizedIngredient.fromItems(item);
+          String prim = primitive.getAsString();
+          if(primitive.getAsString().startsWith("#")) {
+            return SizedIngredient.fromTag(ForgeRegistries.ITEMS.tags().createTagKey(new ResourceLocation(prim.substring(1))));
+          }
+          else {
+            Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(prim));
+            return SizedIngredient.fromItems(item);
+          }
         }
       }
 

--- a/src/main/java/slimeknights/mantle/client/book/data/element/IngredientData.java
+++ b/src/main/java/slimeknights/mantle/client/book/data/element/IngredientData.java
@@ -143,7 +143,7 @@ public class IngredientData implements IDataElement {
 
         if(primitive.isString()) {
           String prim = primitive.getAsString();
-          if(primitive.getAsString().startsWith("#")) {
+          if(prim.startsWith("#")) {
             return SizedIngredient.fromTag(ForgeRegistries.ITEMS.tags().createTagKey(new ResourceLocation(prim.substring(1))));
           }
           else {

--- a/src/main/resources/assets/mantle/books/test/en_us/basic/showcase_tag.json
+++ b/src/main/resources/assets/mantle/books/test/en_us/basic/showcase_tag.json
@@ -1,0 +1,9 @@
+{
+  "title": "Showcase",
+  "text": [
+    {
+      "text": "Above is an tag"
+    }
+  ],
+  "item": "#minecraft:dirt"
+}

--- a/src/main/resources/assets/mantle/books/test/sections/basic.json
+++ b/src/main/resources/assets/mantle/books/test/sections/basic.json
@@ -88,5 +88,10 @@
     "name": "showcase",
     "type": "showcase",
     "data": "basic/showcase.json"
+  },
+    {
+    "name": "showcase_tag",
+    "type": "showcase",
+    "data": "basic/showcase_tag.json"
   }
 ]


### PR DESCRIPTION
I added a bit of code inside of the Deserializer readIngredient method to allow tags to be loaded.

for IngredientData to load the ingredient as a tag, it need to start with `#`

it's the same PR as the other one but for 1.19