### PR TITLE
Backport new BookCommand from 1.20

### DIFF
--- a/src/main/java/slimeknights/mantle/client/ClientEvents.java
+++ b/src/main/java/slimeknights/mantle/client/ClientEvents.java
@@ -37,6 +37,7 @@ import slimeknights.mantle.client.model.inventory.InventoryModel;
 import slimeknights.mantle.client.model.util.ColoredBlockModel;
 import slimeknights.mantle.client.model.util.MantleItemLayerModel;
 import slimeknights.mantle.client.model.util.ModelHelper;
+import slimeknights.mantle.command.client.MantleClientCommand;
 import slimeknights.mantle.fluid.texture.FluidTextureManager;
 import slimeknights.mantle.fluid.tooltip.FluidTooltipHandler;
 import slimeknights.mantle.registration.MantleRegistrations;
@@ -73,6 +74,7 @@ public class ClientEvents {
     event.enqueueWork(() -> RegistrationHelper.forEachWoodType(Sheets::addWoodType));
 
     BookLoader.registerBook(Mantle.getResource("test"), new FileRepository(Mantle.getResource("books/test")));
+    MantleClientCommand.init();
   }
 
   @SubscribeEvent

--- a/src/main/java/slimeknights/mantle/client/book/BookLoader.java
+++ b/src/main/java/slimeknights/mantle/client/book/BookLoader.java
@@ -173,6 +173,13 @@ public class BookLoader implements ResourceManagerReloadListener {
   }
 
   /**
+   * Gets the resource location of all registered books
+   */
+  public static Iterable<ResourceLocation> getRegisteredBooks() {
+    return books.keySet();
+  }
+
+  /**
    * Updates the saved page of a held book
    * @param player  Player instance
    * @param hand    Hand

--- a/src/main/java/slimeknights/mantle/client/screen/book/BookScreen.java
+++ b/src/main/java/slimeknights/mantle/client/screen/book/BookScreen.java
@@ -54,6 +54,10 @@ public class BookScreen extends Screen {
 
   private ArrowButton previousArrow, nextArrow, backArrow, indexArrow;
 
+  // Used for the book to image exporter to disable arrows and mouse input
+  public boolean drawArrows = true;
+  public boolean mouseInput = true;
+
   public final BookData book;
   @Nullable
   private final Consumer<String> pageUpdater;
@@ -329,9 +333,9 @@ public class BookScreen extends Screen {
   public void tick() {
     super.tick();
 
-    this.previousArrow.visible = this.page != -1;
-    this.nextArrow.visible = this.page + 1 < this.book.getFullPageCount(this.advancementCache);
-    this.backArrow.visible = this.oldPage >= -1;
+    this.previousArrow.visible = this.page != -1 && drawArrows;
+    this.nextArrow.visible = this.page + 1 < this.book.getFullPageCount(this.advancementCache) && drawArrows;
+    this.backArrow.visible = this.oldPage >= -1 && drawArrows;
 
     if (this.page == -1) {
       this.nextArrow.x = this.width / 2 + 80;
@@ -341,7 +345,7 @@ public class BookScreen extends Screen {
       this.nextArrow.x = this.width / 2 + 165;
 
       SectionData index = this.book.findSection("index", this.advancementCache);
-      this.indexArrow.visible = index != null && (this.page - 1) * 2 + 2 > index.getPageCount();
+      this.indexArrow.visible = index != null && (this.page - 1) * 2 + 2 > index.getPageCount() && drawArrows;
     }
 
     this.previousArrow.y = this.height / 2 + 75;
@@ -349,24 +353,28 @@ public class BookScreen extends Screen {
   }
 
   /** Goes to the previous page */
-  private void previousPage() {
+  public boolean previousPage() {
     this.page--;
     if (this.page < -1) {
       this.page = -1;
+      return false;
     }
     this.oldPage = -2;
     this.buildPages();
+    return true;
   }
 
   /** Goes to the next page */
-  private void nextPage() {
+  public boolean nextPage() {
     this.page++;
     int fullPageCount = this.book.getFullPageCount(this.advancementCache);
     if (this.page >= fullPageCount) {
       this.page = fullPageCount - 1;
+      return false;
     }
     this.oldPage = -2;
     this.buildPages();
+    return true;
   }
 
   @Override
@@ -534,11 +542,19 @@ public class BookScreen extends Screen {
 
   protected int getMouseX(boolean rightSide) {
     assert this.minecraft != null;
+    if(!mouseInput) {
+      return -1;
+    }
+
     return (int) ((Minecraft.getInstance().mouseHandler.xpos() * this.width / this.minecraft.getWindow().getScreenWidth() - this.leftOffset(rightSide)) / PAGE_SCALE);
   }
 
   protected int getMouseY() {
     assert this.minecraft != null;
+    if(!mouseInput) {
+      return -1;
+    }
+
     return (int) ((Minecraft.getInstance().mouseHandler.ypos() * this.height / this.minecraft.getWindow().getScreenHeight() - 1 - this.topOffset()) / PAGE_SCALE);
   }
 

--- a/src/main/java/slimeknights/mantle/command/BookTestCommand.java
+++ b/src/main/java/slimeknights/mantle/command/BookTestCommand.java
@@ -3,14 +3,13 @@ package slimeknights.mantle.command;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.resources.ResourceLocation;
-import slimeknights.mantle.command.client.BookCommand;
 
 import java.util.HashSet;
 import java.util.Set;
 
 /**
  * Command that opens a test book
- * @deprecated Command is now client-side and lives in {@link BookCommand}
+ * @deprecated Command is now client-side and lives in {@link slimeknights.mantle.command.client.BookCommand}
  */
 public class BookTestCommand {
   private static final Set<ResourceLocation> BOOK_SUGGESTIONS = new HashSet<>();
@@ -18,7 +17,7 @@ public class BookTestCommand {
   /**
    * Registers this sub command with the root command
    * @param subCommand  Command builder
-   * @deprecated Command is now client-side and lives in {@link BookCommand}
+   * @deprecated Command is now client-side and lives in {@link slimeknights.mantle.command.client.BookCommand}
    */
   public static void register(LiteralArgumentBuilder<CommandSourceStack> subCommand) {}
 

--- a/src/main/java/slimeknights/mantle/command/BookTestCommand.java
+++ b/src/main/java/slimeknights/mantle/command/BookTestCommand.java
@@ -1,38 +1,31 @@
 package slimeknights.mantle.command;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
-import com.mojang.brigadier.context.CommandContext;
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.commands.Commands;
-import net.minecraft.commands.arguments.ResourceLocationArgument;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.level.ServerPlayer;
-import slimeknights.mantle.Mantle;
-import slimeknights.mantle.network.MantleNetwork;
-import slimeknights.mantle.network.packet.OpenNamedBookPacket;
+import slimeknights.mantle.command.client.BookCommand;
 
 import java.util.HashSet;
 import java.util.Set;
 
-/** Command that opens a test book */
+/**
+ * Command that opens a test book
+ * @deprecated Command is now client-side and lives in {@link BookCommand}
+ */
 public class BookTestCommand {
   private static final Set<ResourceLocation> BOOK_SUGGESTIONS = new HashSet<>();
 
   /**
    * Registers this sub command with the root command
    * @param subCommand  Command builder
+   * @deprecated Command is now client-side and lives in {@link BookCommand}
    */
-  public static void register(LiteralArgumentBuilder<CommandSourceStack> subCommand) {
-    subCommand.requires(source -> source.hasPermission(MantleCommand.PERMISSION_GAME_COMMANDS) && source.getEntity() instanceof ServerPlayer)
-      .then(Commands.argument("id", ResourceLocationArgument.id()).suggests(MantleCommand.REGISTERED_BOOKS)
-        .executes(BookTestCommand::runBook))
-      .executes(BookTestCommand::run);
-  }
+  public static void register(LiteralArgumentBuilder<CommandSourceStack> subCommand) {}
 
   /**
    * Adds a book suggestion to the list of suggestions
    * @param suggestion The suggestion to be added
+   * @deprecated This method is no longer relevant due to the command becoming client-side
    */
   public static void addBookSuggestion(ResourceLocation suggestion) {
     BOOK_SUGGESTIONS.add(suggestion);
@@ -41,34 +34,9 @@ public class BookTestCommand {
   /**
    * Gets all book suggestions
    * @return The suggestions as stream
+   * @deprecated Use {@link slimeknights.mantle.client.book.BookLoader#getRegisteredBooks()} instead
    */
   public static Iterable<ResourceLocation> getBookSuggestions() {
     return BOOK_SUGGESTIONS;
-  }
-
-  /**
-   * Runs the book-test command for specific book
-   * @param context  Command context
-   * @return  Integer return
-   * @throws  CommandSyntaxException if sender is not a player
-   */
-  private static int runBook(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
-    ResourceLocation book = ResourceLocationArgument.getId(context, "id");
-
-    CommandSourceStack source = context.getSource();
-    MantleNetwork.INSTANCE.sendTo(new OpenNamedBookPacket(book), source.getPlayerOrException());
-    return 0;
-  }
-
-  /**
-   * Runs the book-test command
-   * @param context  Command context
-   * @return  Integer return
-   * @throws  CommandSyntaxException if sender is not a player
-   */
-  private static int run(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
-    CommandSourceStack source = context.getSource();
-    MantleNetwork.INSTANCE.sendTo(new OpenNamedBookPacket(Mantle.getResource("test")), source.getPlayerOrException());
-    return 0;
   }
 }

--- a/src/main/java/slimeknights/mantle/command/BookTestCommand.java
+++ b/src/main/java/slimeknights/mantle/command/BookTestCommand.java
@@ -11,6 +11,7 @@ import java.util.Set;
  * Command that opens a test book
  * @deprecated Command is now client-side and lives in {@link slimeknights.mantle.command.client.BookCommand}
  */
+@Deprecated(forRemoval = true)
 public class BookTestCommand {
   private static final Set<ResourceLocation> BOOK_SUGGESTIONS = new HashSet<>();
 
@@ -19,6 +20,7 @@ public class BookTestCommand {
    * @param subCommand  Command builder
    * @deprecated Command is now client-side and lives in {@link slimeknights.mantle.command.client.BookCommand}
    */
+  @Deprecated(forRemoval = true)
   public static void register(LiteralArgumentBuilder<CommandSourceStack> subCommand) {}
 
   /**
@@ -26,6 +28,7 @@ public class BookTestCommand {
    * @param suggestion The suggestion to be added
    * @deprecated This method is no longer relevant due to the command becoming client-side
    */
+  @Deprecated(forRemoval = true)
   public static void addBookSuggestion(ResourceLocation suggestion) {
     BOOK_SUGGESTIONS.add(suggestion);
   }
@@ -35,6 +38,7 @@ public class BookTestCommand {
    * @return The suggestions as stream
    * @deprecated Use {@link slimeknights.mantle.client.book.BookLoader#getRegisteredBooks()} instead
    */
+  @Deprecated(forRemoval = true)
   public static Iterable<ResourceLocation> getBookSuggestions() {
     return BOOK_SUGGESTIONS;
   }

--- a/src/main/java/slimeknights/mantle/command/ClearBookCacheCommand.java
+++ b/src/main/java/slimeknights/mantle/command/ClearBookCacheCommand.java
@@ -1,49 +1,17 @@
 package slimeknights.mantle.command;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
-import com.mojang.brigadier.context.CommandContext;
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.commands.Commands;
-import net.minecraft.commands.arguments.ResourceLocationArgument;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.level.ServerPlayer;
-import slimeknights.mantle.network.MantleNetwork;
-import slimeknights.mantle.network.packet.ClearBookCachePacket;
 
-/** Command that clears the cache of a book or all books, faster than resource pack reloading for book writing */
+/**
+ * Command that clears the cache of a book or all books, faster than resource pack reloading for book writing
+ * @deprecated Command is now client-side and lives in {@link slimeknights.mantle.command.client.ClearBookCacheCommand}
+ */
 public class ClearBookCacheCommand {
   /**
    * Registers this sub command with the root command
    * @param subCommand  Command builder
+   * @deprecated Command is now client-side and lives in {@link slimeknights.mantle.command.client.ClearBookCacheCommand}
    */
-  public static void register(LiteralArgumentBuilder<CommandSourceStack> subCommand) {
-    subCommand.requires(source -> source.getEntity() instanceof ServerPlayer)
-              .then(Commands.argument("id", ResourceLocationArgument.id()).suggests(MantleCommand.REGISTERED_BOOKS)
-                            .executes(ClearBookCacheCommand::runBook))
-              .executes(ClearBookCacheCommand::runAll);
-  }
-
-  /**
-   * Runs the book-test command for specific book
-   * @param context  Command context
-   * @return  Integer return
-   * @throws CommandSyntaxException if sender is not a player
-   */
-  private static int runBook(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
-    ResourceLocation book = ResourceLocationArgument.getId(context, "id");
-    MantleNetwork.INSTANCE.sendTo(new ClearBookCachePacket(book), context.getSource().getPlayerOrException());
-    return 0;
-  }
-
-  /**
-   * Runs the book-test command
-   * @param context  Command context
-   * @return  Integer return
-   * @throws  CommandSyntaxException if sender is not a player
-   */
-  private static int runAll(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
-    MantleNetwork.INSTANCE.sendTo(new ClearBookCachePacket((ResourceLocation)null), context.getSource().getPlayerOrException());
-    return 0;
-  }
+  public static void register(LiteralArgumentBuilder<CommandSourceStack> subCommand) {}
 }

--- a/src/main/java/slimeknights/mantle/command/ClearBookCacheCommand.java
+++ b/src/main/java/slimeknights/mantle/command/ClearBookCacheCommand.java
@@ -7,11 +7,13 @@ import net.minecraft.commands.CommandSourceStack;
  * Command that clears the cache of a book or all books, faster than resource pack reloading for book writing
  * @deprecated Command is now client-side and lives in {@link slimeknights.mantle.command.client.ClearBookCacheCommand}
  */
+@Deprecated(forRemoval = true)
 public class ClearBookCacheCommand {
   /**
    * Registers this sub command with the root command
    * @param subCommand  Command builder
    * @deprecated Command is now client-side and lives in {@link slimeknights.mantle.command.client.ClearBookCacheCommand}
    */
+  @Deprecated(forRemoval = true)
   public static void register(LiteralArgumentBuilder<CommandSourceStack> subCommand) {}
 }

--- a/src/main/java/slimeknights/mantle/command/MantleCommand.java
+++ b/src/main/java/slimeknights/mantle/command/MantleCommand.java
@@ -32,7 +32,10 @@ public class MantleCommand {
   public static SuggestionProvider<CommandSourceStack> VALID_TAGS;
   /** Suggestion provider that lists tags values for this registry */
   public static SuggestionProvider<CommandSourceStack> REGISTRY_VALUES;
-  /** Suggestion provider that lists registered book ids **/
+  /**
+   * Suggestion provider that lists registered book ids
+   * @deprecated Use {@link slimeknights.mantle.client.book.BookLoader#getRegisteredBooks()} instead
+   **/
   public static SuggestionProvider<CommandSourceStack> REGISTERED_BOOKS;
   /** Suggestion provider that lists registered book ids **/
   public static SuggestionProvider<CommandSourceStack> REGISTRY;
@@ -48,10 +51,11 @@ public class MantleCommand {
       Registry<?> result = RegistryArgument.getResult(context, "type");
       return SharedSuggestionProvider.suggestResource(result.keySet(), builder);
     });
-    REGISTERED_BOOKS = SuggestionProviders.register(Mantle.getResource("registered_books"), (context, builder) ->
-      SharedSuggestionProvider.suggestResource(BookTestCommand.getBookSuggestions(), builder));
     REGISTRY = SuggestionProviders.register(Mantle.getResource("registry"), (context, builder) ->
       SharedSuggestionProvider.suggestResource(context.getSource().registryAccess().registries().map(entry -> entry.key().location()), builder));
+
+    REGISTERED_BOOKS = SuggestionProviders.register(Mantle.getResource("registered_books_legacy"), (context, builder) ->
+      SharedSuggestionProvider.suggestResource(BookTestCommand.getBookSuggestions(), builder));
 
     // add command listener
     MinecraftForge.EVENT_BUS.addListener(MantleCommand::registerCommand);
@@ -74,8 +78,6 @@ public class MantleCommand {
     register(builder, "dump_loot_modifiers", DumpLootModifiers::register);
     register(builder, "dump_all_tags", DumpAllTagsCommand::register);
     register(builder, "tags_for", TagsForCommand::register);
-    register(builder, "book_test", BookTestCommand::register);
-    register(builder, "clear_book_cache", ClearBookCacheCommand::register);
     register(builder, "harvest_tiers", HarvestTiersCommand::register);
     register(builder, "tag_preference", TagPreferenceCommand::register);
 

--- a/src/main/java/slimeknights/mantle/command/MantleCommand.java
+++ b/src/main/java/slimeknights/mantle/command/MantleCommand.java
@@ -34,8 +34,9 @@ public class MantleCommand {
   public static SuggestionProvider<CommandSourceStack> REGISTRY_VALUES;
   /**
    * Suggestion provider that lists registered book ids
-   * @deprecated Use {@link slimeknights.mantle.client.book.BookLoader#getRegisteredBooks()} instead
+   * @deprecated Use {@link slimeknights.mantle.command.client.MantleClientCommand#REGISTERED_BOOKS} instead
    **/
+  @Deprecated(forRemoval = true)
   public static SuggestionProvider<CommandSourceStack> REGISTERED_BOOKS;
   /** Suggestion provider that lists registered book ids **/
   public static SuggestionProvider<CommandSourceStack> REGISTRY;

--- a/src/main/java/slimeknights/mantle/command/client/BookCommand.java
+++ b/src/main/java/slimeknights/mantle/command/client/BookCommand.java
@@ -66,7 +66,10 @@ public class BookCommand {
 
     BookData bookData = BookLoader.getBook(book);
     if(bookData != null) {
-      bookData.openGui(Component.literal("Book"), "", null, null);
+      // Delay execution to ensure chat window is closed
+      Minecraft.getInstance().tell(() ->
+        bookData.openGui(Component.literal("Book"), "", null, null)
+      );
     } else {
       bookNotFound(book);
       return 1;

--- a/src/main/java/slimeknights/mantle/command/client/BookCommand.java
+++ b/src/main/java/slimeknights/mantle/command/client/BookCommand.java
@@ -1,0 +1,233 @@
+package slimeknights.mantle.command.client;
+
+import com.mojang.blaze3d.pipeline.RenderTarget;
+import com.mojang.blaze3d.pipeline.TextureTarget;
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.mojang.blaze3d.platform.Lighting;
+import com.mojang.blaze3d.platform.NativeImage;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.math.Matrix4f;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.commands.CommandRuntimeException;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.ResourceLocationArgument;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+import org.lwjgl.opengl.GL11;
+import slimeknights.mantle.Mantle;
+import slimeknights.mantle.client.book.BookLoader;
+import slimeknights.mantle.client.book.data.BookData;
+import slimeknights.mantle.client.screen.book.BookScreen;
+import slimeknights.mantle.command.MantleCommand;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/** A command for different book */
+public class BookCommand {
+  private static final String BOOK_NOT_FOUND = "command.mantle.book_test.not_found";
+
+  private static final String EXPORT_SUCCESS = "command.mantle.book.export.success";
+  private static final String EXPORT_FAIL = "command.mantle.book.export.error_generic";
+  private static final String EXPORT_FAIL_IO = "command.mantle.book.export.error_io";
+
+  /**
+   * Registers this sub command with the root command
+   * @param subCommand  Command builder
+   */
+  public static void register(LiteralArgumentBuilder<CommandSourceStack> subCommand) {
+    subCommand.requires(source -> source.hasPermission(MantleCommand.PERMISSION_GAME_COMMANDS) && source.getEntity() instanceof AbstractClientPlayer)
+      .then(Commands.literal("open")
+        .then(Commands.argument("id", ResourceLocationArgument.id()).suggests(MantleClientCommand.REGISTERED_BOOKS)
+          .executes(BookCommand::openBook)))
+      .then(Commands.literal("export_images")
+        .then(Commands.argument("id", ResourceLocationArgument.id()).suggests(MantleClientCommand.REGISTERED_BOOKS)
+          .then(Commands.argument("scale", IntegerArgumentType.integer(1, 16))
+            .executes(BookCommand::exportImagesWithScale))
+          .executes(BookCommand::exportImages)));
+  }
+
+  /**
+   * Opens the specified book
+   * @param context  Command context
+   * @return  Integer return
+   */
+  private static int openBook(CommandContext<CommandSourceStack> context) {
+    ResourceLocation book = ResourceLocationArgument.getId(context, "id");
+
+    BookData bookData = BookLoader.getBook(book);
+    if(bookData != null) {
+      bookData.openGui(Component.literal("Book"), "", null, null);
+    } else {
+      bookNotFound(book);
+      return 1;
+    }
+
+    return 0;
+  }
+
+  /**
+   * Renders all images in the book to files at specified scale
+   * @param context  Command context
+   * @return  Integer return
+   */
+  private static int exportImagesWithScale(CommandContext<CommandSourceStack> context) {
+    ResourceLocation book = ResourceLocationArgument.getId(context, "id");
+    int scale = context.getArgument("scale", Integer.class);
+
+    return doExportImages(book, scale);
+  }
+
+  /**
+   * Renders all images in the book to files
+   * @param context  Command context
+   * @return  Integer return
+   */
+  private static int exportImages(CommandContext<CommandSourceStack> context) {
+    ResourceLocation book = ResourceLocationArgument.getId(context, "id");
+
+    return doExportImages(book, 1);
+  }
+
+  /**
+   * Renders all images in the book to files
+   * @param book  Book to export
+   * @param scale  Scale to export at
+   * @return  Integer return
+   */
+  private static int doExportImages(ResourceLocation book, int scale) {
+    BookData bookData = BookLoader.getBook(book);
+
+    Path gameDirectory = Minecraft.getInstance().gameDirectory.toPath();
+    Path screenshotDir = Paths.get(gameDirectory.toString(), "screenshots", "mantle_book", book.getNamespace(), book.getPath());
+
+    if(bookData != null) {
+      if(!screenshotDir.toFile().mkdirs() && !screenshotDir.toFile().exists()) {
+        throw new CommandRuntimeException(Component.translatable(EXPORT_FAIL_IO));
+      }
+
+      int width = BookScreen.PAGE_WIDTH_UNSCALED * 2 * scale;
+      int height = BookScreen.PAGE_HEIGHT_UNSCALED * scale;
+      float zFar = 1000.0F + 10000.0F * 3;
+
+      bookData.load();
+      BookScreen screen = new BookScreen(Component.literal("Book"), bookData, "", null, null);
+      screen.init(Minecraft.getInstance(), width / scale, height / scale);
+      screen.drawArrows = false;
+      screen.mouseInput = false;
+
+      Matrix4f matrix = Matrix4f.orthographic(0, width, 0, height, 1000.0F, zFar);
+      RenderSystem.setProjectionMatrix(matrix);
+
+      PoseStack stack = RenderSystem.getModelViewStack();
+      stack.pushPose();
+      stack.setIdentity();
+      stack.translate(0, 0, 1000F - zFar);
+      stack.scale(scale, scale, 1);
+      RenderSystem.applyModelViewMatrix();
+      Lighting.setupFor3DItems();
+
+      RenderTarget target = new TextureTarget(width, height, true, Minecraft.ON_OSX);
+      target.enableStencil();
+
+      try {
+        target.bindWrite(true);
+
+        PoseStack guiPose = new PoseStack();
+
+        do {
+          RenderSystem.clear(GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT, Minecraft.ON_OSX);
+
+          screen.tick();
+
+          RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,
+            GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ONE);
+
+          guiPose.pushPose();
+          screen.render(guiPose, 0, 0, 0);
+          guiPose.popPose();
+
+          try (NativeImage image = takeScreenshot(target)) {
+            int page = screen.getPage_();
+            String pageFormat = page < 0 ? "cover" : "page_" + page;
+            Path path = Paths.get(screenshotDir.toString(), pageFormat + ".png");
+
+            if (page == -1) { // the cover is half the width
+              try (NativeImage scaled = new NativeImage(image.format(), width / 2, height, false)) {
+                copyRect(image, scaled, image.getWidth() / 2 - width / 4, 0, 0, 0,
+                  width / 2, height);
+                scaled.writeToFile(path);
+              } catch (Exception e) {
+                Mantle.logger.error("Failed to save screenshot", e);
+                throw new CommandRuntimeException(Component.translatable(EXPORT_FAIL));
+              }
+            } else {
+              image.writeToFile(path);
+            }
+          } catch (Exception e) {
+            Mantle.logger.error("Failed to save screenshot", e);
+            throw new CommandRuntimeException(Component.translatable(EXPORT_FAIL));
+          }
+        } while (screen.nextPage());
+      } finally {
+        stack.popPose();
+        RenderSystem.applyModelViewMatrix();
+        RenderSystem.defaultBlendFunc();
+        target.unbindWrite();
+        target.destroyBuffers();
+      }
+    } else {
+      bookNotFound(book);
+      return 1;
+    }
+
+    Player player = Minecraft.getInstance().player;
+    if (player != null) {
+      Component fileComponent = Component.literal(screenshotDir.toString()).withStyle(ChatFormatting.UNDERLINE)
+        .withStyle(style -> style.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_FILE, screenshotDir.toAbsolutePath().toString())));
+      player.displayClientMessage(Component.translatable(EXPORT_SUCCESS, fileComponent), false);
+    }
+    return 0;
+  }
+
+  /**
+   * Duplicate of {@link net.minecraft.client.Screenshot#takeScreenshot}, but with transparency
+   */
+  private static NativeImage takeScreenshot(RenderTarget pFramebuffer) {
+    int i = pFramebuffer.width;
+    int j = pFramebuffer.height;
+    NativeImage nativeimage = new NativeImage(i, j, false);
+    RenderSystem.bindTexture(pFramebuffer.getColorTextureId());
+    nativeimage.downloadTexture(0, false);
+    nativeimage.flipY();
+    return nativeimage;
+  }
+
+  /**
+   * Minimalistic backport of NativeImage#copyRect
+   */
+  public static void copyRect(NativeImage src, NativeImage dst, int srcX, int srcY, int dstX, int dstY, int width, int height) {
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        int color = src.getPixelRGBA(srcX + x, srcY + y);
+        dst.setPixelRGBA(dstX + x, dstY + y, color);
+      }
+    }
+  }
+
+  public static void bookNotFound(ResourceLocation book) {
+    Player player = Minecraft.getInstance().player;
+    if (player != null) {
+      player.displayClientMessage(Component.translatable(BOOK_NOT_FOUND, book).withStyle(ChatFormatting.RED), false);
+    }
+  }
+}

--- a/src/main/java/slimeknights/mantle/command/client/BookCommand.java
+++ b/src/main/java/slimeknights/mantle/command/client/BookCommand.java
@@ -32,7 +32,7 @@ import slimeknights.mantle.command.MantleCommand;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-/** A command for different book */
+/** A command for different book operations, currently open and export_images */
 public class BookCommand {
   private static final String BOOK_NOT_FOUND = "command.mantle.book_test.not_found";
 

--- a/src/main/java/slimeknights/mantle/command/client/ClearBookCacheCommand.java
+++ b/src/main/java/slimeknights/mantle/command/client/ClearBookCacheCommand.java
@@ -1,0 +1,68 @@
+package slimeknights.mantle.command.client;
+
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.ResourceLocationArgument;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import slimeknights.mantle.client.book.BookLoader;
+import slimeknights.mantle.client.book.data.BookData;
+import slimeknights.mantle.command.MantleCommand;
+import slimeknights.mantle.network.MantleNetwork;
+import slimeknights.mantle.network.packet.ClearBookCachePacket;
+
+import javax.annotation.Nullable;
+
+/** Command that clears the cache of a book or all books, faster than resource pack reloading for book writing */
+public class ClearBookCacheCommand {
+  /**
+   * Registers this sub command with the root command
+   * @param subCommand  Command builder
+   */
+  public static void register(LiteralArgumentBuilder<CommandSourceStack> subCommand) {
+    subCommand.requires(source -> source.getEntity() instanceof AbstractClientPlayer)
+              .then(Commands.argument("id", ResourceLocationArgument.id()).suggests(MantleClientCommand.REGISTERED_BOOKS)
+                            .executes(ClearBookCacheCommand::runBook))
+              .executes(ClearBookCacheCommand::runAll);
+  }
+
+  /**
+   * Runs the book-test command for specific book
+   * @param context  Command context
+   * @return  Integer return
+   * @throws CommandSyntaxException if sender is not a player
+   */
+  private static int runBook(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
+    ResourceLocation book = ResourceLocationArgument.getId(context, "id");
+    clearBookCache(book);
+    return 0;
+  }
+
+  /**
+   * Runs the book-test command
+   * @param context  Command context
+   * @return  Integer return
+   * @throws  CommandSyntaxException if sender is not a player
+   */
+  private static int runAll(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
+    clearBookCache(null);
+    return 0;
+  }
+
+  private static void clearBookCache(@Nullable ResourceLocation book) {
+    if (book != null) {
+      BookData bookData = BookLoader.getBook(book);
+      if (bookData != null) {
+        bookData.reset();
+      } else {
+        BookCommand.bookNotFound(book);
+      }
+    } else {
+      BookLoader.resetAllBooks();
+    }
+  }
+}

--- a/src/main/java/slimeknights/mantle/command/client/MantleClientCommand.java
+++ b/src/main/java/slimeknights/mantle/command/client/MantleClientCommand.java
@@ -1,0 +1,51 @@
+package slimeknights.mantle.command.client;
+
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.commands.synchronization.SuggestionProviders;
+import net.minecraftforge.client.event.RegisterClientCommandsEvent;
+import net.minecraftforge.common.MinecraftForge;
+import slimeknights.mantle.Mantle;
+import slimeknights.mantle.client.book.BookLoader;
+
+import java.util.function.Consumer;
+
+/**
+ * Root command for all commands in mantle
+ */
+public class MantleClientCommand {
+  /** Suggestion provider that lists registered book ids **/
+  public static SuggestionProvider<CommandSourceStack> REGISTERED_BOOKS;
+
+  /** Registers all Mantle command related content */
+  public static void init() {
+    // register arguments
+    REGISTERED_BOOKS = SuggestionProviders.register(Mantle.getResource("registered_books"), (context, builder) ->
+      SharedSuggestionProvider.suggestResource(BookLoader.getRegisteredBooks(), builder));
+
+    // add command listener
+    MinecraftForge.EVENT_BUS.addListener(MantleClientCommand::registerCommand);
+  }
+
+  /** Registers a sub command for the root Mantle client command */
+  private static void register(LiteralArgumentBuilder<CommandSourceStack> root, String name, Consumer<LiteralArgumentBuilder<CommandSourceStack>> consumer) {
+    LiteralArgumentBuilder<CommandSourceStack> subCommand = Commands.literal(name);
+    consumer.accept(subCommand);
+    root.then(subCommand);
+  }
+
+  /** Event listener to register the Mantle client command */
+  private static void registerCommand(RegisterClientCommandsEvent event) {
+    LiteralArgumentBuilder<CommandSourceStack> builder = Commands.literal("mantle");
+
+    // sub commands
+    register(builder, "book", BookCommand::register);
+    register(builder, "clear_book_cache", ClearBookCacheCommand::register);
+
+    // register final command
+    event.getDispatcher().register(builder);
+  }
+}

--- a/src/main/java/slimeknights/mantle/command/client/package-info.java
+++ b/src/main/java/slimeknights/mantle/command/client/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package slimeknights.mantle.command.client;
+
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/slimeknights/mantle/network/packet/ClearBookCachePacket.java
+++ b/src/main/java/slimeknights/mantle/network/packet/ClearBookCachePacket.java
@@ -9,7 +9,10 @@ import slimeknights.mantle.network.packet.OpenNamedBookPacket.ClientOnly;
 
 import javax.annotation.Nullable;
 
-/** Packet sent by {@link slimeknights.mantle.command.ClearBookCacheCommand} to reset a book cache */
+/**
+ * Packet sent by {@link slimeknights.mantle.command.ClearBookCacheCommand} to reset a book cache
+ * @deprecated Command is now client-side, making this redundant
+ */
 public record ClearBookCachePacket(@Nullable ResourceLocation book) implements IThreadsafePacket {
   public ClearBookCachePacket(FriendlyByteBuf buffer) {
     this(buffer.readBoolean() ? buffer.readResourceLocation() : null);

--- a/src/main/java/slimeknights/mantle/network/packet/OpenNamedBookPacket.java
+++ b/src/main/java/slimeknights/mantle/network/packet/OpenNamedBookPacket.java
@@ -1,15 +1,13 @@
 package slimeknights.mantle.network.packet;
 
 import lombok.AllArgsConstructor;
-import net.minecraft.ChatFormatting;
-import net.minecraft.client.Minecraft;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.network.NetworkEvent;
 import slimeknights.mantle.client.book.BookLoader;
 import slimeknights.mantle.client.book.data.BookData;
+import slimeknights.mantle.command.client.BookCommand;
 
 @AllArgsConstructor
 public class OpenNamedBookPacket implements IThreadsafePacket {
@@ -37,10 +35,7 @@ public class OpenNamedBookPacket implements IThreadsafePacket {
 
   static class ClientOnly {
     static void errorStatus(ResourceLocation book) {
-      Player player = Minecraft.getInstance().player;
-      if (player != null) {
-        player.displayClientMessage(Component.translatable(BOOK_ERROR, book).withStyle(ChatFormatting.RED), false);
-      }
+      BookCommand.bookNotFound(book);
     }
   }
 }

--- a/src/main/resources/assets/mantle/lang/en_us.json
+++ b/src/main/resources/assets/mantle/lang/en_us.json
@@ -15,6 +15,9 @@
   "command.mantle.tags_for.no_targeted_block_entity": "No targeted block entity",
   "command.mantle.tags_for.no_tags": "No tags",
   "command.mantle.book_test.not_found": "Unknown book with ID %s",
+  "command.mantle.book.export.success": "Exported book images to '%s'",
+  "command.mantle.book.export.error_generic": "Failed to export book images, see log for details",
+  "command.mantle.book.export.error_io": "Failed to create directory for book images '%s'",
 
   "command.mantle.dump_tag.success": "Printed combined %s tag '%s' to console log",
   "command.mantle.dump_tag.read_error": "Error reading %s tag '%s':",


### PR DESCRIPTION
- Refactored BookTestCommand into BookCommand, with open and export_images as two separate subcommands
  - Deprecated original BookTestCommand
- Added a client-side version of the mantle command
- Moved BookCommand and ClearBookCacheCommand into MantleClientCommand
  - Deprecated originals
- Deprecated ClearBookCachePacket as it is no longer needed