### PR TITLE
Fix UI opening condition to use sneaking check instead of isSuppressingBounce

### DIFF
--- a/src/main/java/slimeknights/mantle/block/InventoryBlock.java
+++ b/src/main/java/slimeknights/mantle/block/InventoryBlock.java
@@ -59,7 +59,7 @@ public abstract class InventoryBlock extends Block implements EntityBlock {
   @Deprecated
   @Override
   public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult rayTraceResult) {
-    if (player.isSuppressingBounce()) {
+    if (player.isShiftKeyDown()) {
       return InteractionResult.PASS;
     }
     if (!world.isClientSide) {


### PR DESCRIPTION
While working on mod compatibility, I discovered a bug where my mod overrides the return value of `isSuppressingBounce` (to implement a "no bounce" feature). This override unintentionally prevented the UI from opening, because the UI logic was checking `isSuppressingBounce` rather than the player's sneaking state.

In general, UI interaction should be based on whether the player is sneaking, not on whether bouncing is suppressed. Other parts of the code (e.g., `LecternBookItem.class`) already use the sneaking check, which is the correct behavior.

This PR changes the UI opening condition to check sneaking instead, ensuring compatibility with other mods that may also modify `isSuppressingBounce` without affecting the intended UI functionality.