### PR TITLE
Fix creative players destroying fluid when filling a container from a tank

### DIFF
--- a/src/main/java/slimeknights/mantle/fluid/FluidTransferHelper.java
+++ b/src/main/java/slimeknights/mantle/fluid/FluidTransferHelper.java
@@ -256,7 +256,9 @@ public class FluidTransferHelper {
             } else {
               playEmptySound(world, pos, player, result.fluid());
             }
-            player.setItemInHand(hand, ItemUtils.createFilledResult(stack, player, result.stack()));
+            // creative does not consume the held stack, so vanilla will discard the result if the inventory already has a match
+            // that is only safe when emptying the container, discarding a filled container destroys the fluid we just drained
+            player.setItemInHand(hand, ItemUtils.createFilledResult(stack, player, result.stack(), !result.didFill()));
             return result.didFill() ? FluidInteractionResult.FILLED_STACK : FluidInteractionResult.DRAINED_STACK;
           }
         }
@@ -286,7 +288,9 @@ public class FluidTransferHelper {
         }
         // if either worked, update the player's inventory
         if (!transferred.isEmpty()) {
-          player.setItemInHand(hand, ItemUtils.createFilledResult(stack, player, itemHandler.getContainer()));
+          // creative does not consume the held stack, so vanilla will discard the result if the inventory already has a match
+          // that is only safe when emptying the container, discarding a filled container destroys the fluid we just drained
+          player.setItemInHand(hand, ItemUtils.createFilledResult(stack, player, itemHandler.getContainer(), result == FluidInteractionResult.DRAINED_STACK));
         }
       }
       return result;


### PR DESCRIPTION
Right-clicking a tank with a fluid container destroys the fluid in creative mode. FluidTransferHelper.interactWithContainer fills a copy of the held stack and passes the result to ItemUtils.createFilledResult, whose three argument form asks for duplicate prevention. For a creative player that branch leaves the held stack alone and only adds the filled container if Inventory#contains doesn't already find an identical one, and it ignores whether the add succeeded. The tank drain has already been committed by then, so any time the result is discarded the fluid goes with it. Filling a second bucket from the same tank is enough to hit it: the first click hands you a water bucket, the second finds that same bucket already in your inventory and throws the new one away, and the tank is 1000 mb lighter for nothing. Survival is unaffected either way, since that flag is only read when instabuild is set.

The fix passes the flag explicitly instead of taking the default, and only asks for duplicate prevention when the container was emptied rather than filled. An emptied container holds nothing worth keeping, and that direction genuinely wants the check, otherwise you get handed a spare empty bucket on every single click instead of just the first. When the container was filled the result is now always given to the player, dropped at their feet if the inventory happens to be full. The drain itself is correct as it stands, vanilla removes the source block in creative too before it calls createFilledResult, so it's only the delivery that was losing things. Both call sites in that method get the same treatment, the direct capability path and the JSON fluid transfer path.

Tested in game with a seared tank and a plain water bucket, reading the tank with /data get block and counting buckets with /clear @s minecraft:water_bucket 0 (which counts without removing anything):

before: two creative right-clicks, tank 2000 -> 1000 -> empty, but only one water bucket to show for it
![before](https://raw.githubusercontent.com/ryancircelli/Mantle/pr-assets/tankfill-before-creative-void.png)

after: the same two clicks, two water buckets
![after](https://raw.githubusercontent.com/ryancircelli/Mantle/pr-assets/tankfill-after-creative-conserved.png)

Survival is unchanged, two empty buckets still come back as two water buckets and the tank still empties. Emptying a bucket into a tank in creative also behaves exactly as it did before: the tank fills, the water bucket is never consumed, and you get at most one spare empty bucket rather than one per click. I checked the JSON transfer path separately with a glass bottle against a tank of earthslime, 1000 -> 750 -> 500 handing back two bottles.

(#255)

