### PR TITLE
Fix side inventory scroll bar sticking to the cursor when released outside the screen

### DIFF
--- a/src/main/java/slimeknights/mantle/client/screen/ModuleScreen.java
+++ b/src/main/java/slimeknights/mantle/client/screen/ModuleScreen.java
@@ -130,6 +130,21 @@ public abstract class ModuleScreen<P extends MultiModuleScreen<?>, C extends Abs
   }
 
   /**
+   * Variant of {@link #handleMouseReleased(double, double, int)} that is called for every release, including ones the cursor has carried outside this module.
+   * A module tracking a drag needs the button up wherever it lands or it keeps tracking with the button released, but delivering that to every module unconditionally would change behavior for modules that only expect releases they can see, so the default here delegates only when the cursor is still inside.
+   * Override this instead of {@link #handleMouseReleased(double, double, int)} if you track drag state.
+   * TODO 1.21: fold this into {@link #handleMouseReleased(double, double, int)} and remove.
+   *
+   * @return True to prevent the main container handling the mouse release
+   */
+  public boolean handleMouseReleasedAnywhere(double mouseX, double mouseY, int state) {
+    if (this.isMouseInModule((int) mouseX, (int) mouseY)) {
+      return this.handleMouseReleased(mouseX, mouseY, state);
+    }
+    return false;
+  }
+
+  /**
    * Custom mouse scrolled handling.
    *
    * @return True to prevent the main container handling the mouseclick

--- a/src/main/java/slimeknights/mantle/client/screen/MultiModuleScreen.java
+++ b/src/main/java/slimeknights/mantle/client/screen/MultiModuleScreen.java
@@ -276,9 +276,10 @@ public class MultiModuleScreen<CONTAINER extends MultiModuleContainerMenu<?>> ex
   @Override
   public boolean mouseReleased(double mouseX, double mouseY, int state) {
     // every module gets the release, even ones the cursor has left; a module tracking a drag needs the button up to stop tracking
+    // the default implementation still bounds checks before running the module's own handler, so only modules that opt in see releases outside their area
     boolean handled = false;
     for (ModuleScreen<?,?> module : this.modules) {
-      if (module.handleMouseReleased(mouseX, mouseY, state)) {
+      if (module.handleMouseReleasedAnywhere(mouseX, mouseY, state)) {
         handled = true;
       }
     }

--- a/src/main/java/slimeknights/mantle/client/screen/MultiModuleScreen.java
+++ b/src/main/java/slimeknights/mantle/client/screen/MultiModuleScreen.java
@@ -161,10 +161,10 @@ public class MultiModuleScreen<CONTAINER extends MultiModuleContainerMenu<?>> ex
 
   // needed to get the correct slot on clicking
   @Override
-  protected boolean isHovering(int left, int top, int right, int bottom, double pointX, double pointY) {
+  protected boolean isHovering(int left, int top, int width, int height, double pointX, double pointY) {
     pointX -= this.cornerX;
     pointY -= this.cornerY;
-    return pointX >= left - 1 && pointX < left + right + 1 && pointY >= top - 1 && pointY < top + bottom + 1;
+    return pointX >= left - 1 && pointX < left + width + 1 && pointY >= top - 1 && pointY < top + height + 1;
   }
 
   protected void updateSubmodule(ModuleScreen<?,?> module) {
@@ -275,12 +275,16 @@ public class MultiModuleScreen<CONTAINER extends MultiModuleContainerMenu<?>> ex
 
   @Override
   public boolean mouseReleased(double mouseX, double mouseY, int state) {
-    ModuleScreen<?,?> module = this.getModuleForPoint(mouseX, mouseY);
-
-    if (module != null) {
+    // every module gets the release, even ones the cursor has left; a module tracking a drag needs the button up to stop tracking
+    boolean handled = false;
+    for (ModuleScreen<?,?> module : this.modules) {
       if (module.handleMouseReleased(mouseX, mouseY, state)) {
-        return false;
+        handled = true;
       }
+    }
+
+    if (handled) {
+      return false;
     }
 
     return super.mouseReleased(mouseX, mouseY, state);
@@ -289,7 +293,7 @@ public class MultiModuleScreen<CONTAINER extends MultiModuleContainerMenu<?>> ex
   @Nullable
   protected ModuleScreen<?,?> getModuleForPoint(double x, double y) {
     for (ModuleScreen<?,?> module : this.modules) {
-      if (this.isHovering(module.leftPos, module.topPos, module.guiRight(), module.guiBottom(), x + this.cornerX, y + this.cornerY)) {
+      if (this.isHovering(module.leftPos, module.topPos, module.imageWidth, module.imageHeight, x + this.cornerX, y + this.cornerY)) {
         return module;
       }
     }


### PR DESCRIPTION
MultiModuleScreen#mouseReleased only tells the module under the cursor, so a drag that ends anywhere else never gets its release. SliderWidget clears leftMouseDown only from handleMouseReleased, and the side inventory re-runs the slider's update every frame it draws, so the bar goes on tracking the cursor with the button up until you happen to release inside the panel again.

Per the review, the release now reaches modules through a new handleMouseReleasedAnywhere rather than by widening the existing method. Its default implementation checks isMouseInModule and delegates to handleMouseReleased only when the cursor is inside, so a module that does not override it sees exactly the releases it saw before, and it carries a TODO 1.21 to fold back into the one method. Since the slider-owning module screens live in Tinkers, this PR is the hook; the matching one-line overrides are ready as a companion Tinkers PR.

The second change is why only the top edge sticks today. getModuleForPoint passes guiRight() and guiBottom() into isHovering, which takes a width and a height, so the right and bottom bounds come out inflated by a whole module origin and quietly catch releases that should have missed. That is the asymmetry in the report. isHovering's parameters are renamed to match what its body already does with them.

Tested in game on a crafting station with a large chest beside it, with the three Tinkers overrides applied so the whole path runs: drag the side inventory bar, release above the panel, then move the mouse back down with the button up.

before: the bar follows the cursor down
![before](https://raw.githubusercontent.com/ryancircelli/Mantle/pr-assets/4897v2-before-slider-follows-cursor.png)

after: the bar stays where it was released
![after](https://raw.githubusercontent.com/ryancircelli/Mantle/pr-assets/4897v2-after-slider-stays.png)

Releasing inside the panel still leaves the bar where you dropped it, a Tinker Station with slider-less info panels behaves identically under presses and releases far outside it, and the scroll wheel, slot tooltips, and slot pick and place all still work.

Report: SlimeKnights/TinkersConstruct#4897
