### PR TITLE
Fall back to English inside translate() for missing book translation keys

### DIFF
--- a/src/main/java/slimeknights/mantle/client/book/data/BookData.java
+++ b/src/main/java/slimeknights/mantle/client/book/data/BookData.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 @SuppressWarnings("unused")  // API
@@ -36,6 +37,13 @@ public class BookData implements IDataItem, BookScreenOpener {
   public transient ArrayList<SectionData> sections = new ArrayList<>();
   public transient AppearanceData appearance = new AppearanceData();
   public transient HashMap<String, String> strings = new HashMap<>();
+  /**
+   * Translations from the book's English language file, used by {@link #translate(String)} as a last resort for keys missing from {@link #strings}.
+   * Holds only the keys {@link #strings} lacks, and is left empty when English is the selected language.
+   * Kept out of {@link #strings} as the presence of a key there doubles as a flag for optional translations, notably page title overrides and listing subtext.
+   * Merging the two maps would make those elements show up in English instead of staying absent.
+   */
+  public transient HashMap<String, String> fallbackStrings = new HashMap<>();
   public transient Font fontRenderer;
   private transient boolean initialized = false;
 
@@ -64,7 +72,11 @@ public class BookData implements IDataItem, BookScreenOpener {
       this.initialized = true;
       this.sections.clear();
       this.strings.clear();
+      this.fallbackStrings.clear();
       this.appearance = new AppearanceData();
+
+      // English is only worth loading as a fallback when it is not the language being displayed
+      boolean loadEnglishFallback = !BookRepository.DEFAULT_LANGUAGE.equals(BookRepository.getSelectedLanguage());
 
       for (BookRepository repo : this.repositories) {
         try {
@@ -100,27 +112,20 @@ public class BookData implements IDataItem, BookScreenOpener {
         ResourceLocation languageLocation = repo.getResourceLocation("language.lang");
 
         if (repo.resourceExists(languageLocation)) {
-          try {
-            Resource resource = repo.getResource(languageLocation);
-            if (resource != null) {
-              BufferedReader br = new BufferedReader(new InputStreamReader(resource.open(), StandardCharsets.UTF_8));
-              String next = br.readLine();
+          loadStrings(repo, languageLocation, this.strings);
 
-              while (next != null) {
-                if (!next.startsWith("//") && next.contains("=")) {
-                  String key = next.substring(0, next.indexOf('='));
-                  String value = next.substring(next.indexOf('=') + 1);
-
-                  this.strings.put(key, value);
-                }
-
-                next = br.readLine();
-              }
+          if (loadEnglishFallback) {
+            // the book may have no file for the selected language at all, in which case the cascade above already landed on English
+            ResourceLocation fallbackLocation = repo.getLanguageResourceLocation("language.lang", BookRepository.DEFAULT_LANGUAGE);
+            if (fallbackLocation != null && !fallbackLocation.equals(languageLocation)) {
+              loadStrings(repo, fallbackLocation, this.fallbackStrings);
             }
-          } catch (Exception ignored) {
           }
         }
       }
+
+      // the fallback is only ever read for keys the selected language is missing, so drop everything the language already defines to save memory
+      this.fallbackStrings.keySet().removeAll(this.strings.keySet());
 
       // set unicode font if requested
       if (this.appearance.uniformFont) {
@@ -194,6 +199,29 @@ public class BookData implements IDataItem, BookScreenOpener {
     }
 
     Mantle.logger.info("Finished loading book");
+  }
+
+  /** Reads every key value pair from the given language file into the given map */
+  private static void loadStrings(BookRepository repo, ResourceLocation location, Map<String, String> strings) {
+    try {
+      Resource resource = repo.getResource(location);
+      if (resource != null) {
+        BufferedReader br = new BufferedReader(new InputStreamReader(resource.open(), StandardCharsets.UTF_8));
+        String next = br.readLine();
+
+        while (next != null) {
+          if (!next.startsWith("//") && next.contains("=")) {
+            String key = next.substring(0, next.indexOf('='));
+            String value = next.substring(next.indexOf('=') + 1);
+
+            strings.put(key, value);
+          }
+
+          next = br.readLine();
+        }
+      }
+    } catch (Exception ignored) {
+    }
   }
 
   /** Finds the section with the given name, ignoring advancements */
@@ -342,9 +370,12 @@ public class BookData implements IDataItem, BookScreenOpener {
     return visible;
   }
 
-  /** Translates the given string using the book language */
+  /** Translates the given string using the book language, falling back to English and then to the key itself */
   public String translate(String string) {
     String out = this.strings.get(string);
+    if (out == null) {
+      out = this.fallbackStrings.get(string);
+    }
     return out != null ? out : string;
   }
 

--- a/src/main/java/slimeknights/mantle/client/book/data/PageData.java
+++ b/src/main/java/slimeknights/mantle/client/book/data/PageData.java
@@ -159,6 +159,8 @@ public class PageData implements IDataItem, IConditional {
 
   /** Gets the title for the page data, which can be overridden by translation */
   public String getTitle() {
+    // deliberately skips the English fallback: this key is an optional override for languages where the content's own title is a poor fit,
+    // so a language that leaves it out wants its own content title rather than the English override
     String title = this.parent.parent.strings.get(this.parent.name + "." + this.name);
     if (title != null) {
       return title;

--- a/src/main/java/slimeknights/mantle/client/book/data/SectionData.java
+++ b/src/main/java/slimeknights/mantle/client/book/data/SectionData.java
@@ -110,8 +110,7 @@ public class SectionData implements IDataItem, IConditional, IHTML {
   }
 
   public String getTitle() {
-    String title = this.parent.strings.get(this.name);
-    return title == null ? this.name : title;
+    return this.translate(this.name);
   }
 
   public int getPageCount() {

--- a/src/main/java/slimeknights/mantle/client/book/repository/BookRepository.java
+++ b/src/main/java/slimeknights/mantle/client/book/repository/BookRepository.java
@@ -1,5 +1,6 @@
 package slimeknights.mantle.client.book.repository;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.Resource;
 import slimeknights.mantle.client.book.data.SectionData;
@@ -13,6 +14,22 @@ public abstract class BookRepository {
   @SuppressWarnings("StaticInitializerReferencesSubClass") // will only occur in very specific threaded environment
   public static final BookRepository DUMMY = new DummyRepository();
 
+  /** Language a book falls back to when the selected language is missing a file */
+  public static final String DEFAULT_LANGUAGE = "en_us";
+
+  /** Gets the language selected in the client options, or {@link #DEFAULT_LANGUAGE} if there is none yet */
+  public static String getSelectedLanguage() {
+    //noinspection ConstantConditions - this was proven to be null once
+    if (Minecraft.getInstance().getLanguageManager() != null) {
+      String selected = Minecraft.getInstance().getLanguageManager().getSelected();
+      //noinspection ConstantConditions - see above
+      if (selected != null) {
+        return selected;
+      }
+    }
+    return DEFAULT_LANGUAGE;
+  }
+
   public abstract List<SectionData> getSections();
 
   @Nullable
@@ -22,6 +39,18 @@ public abstract class BookRepository {
 
   @Nullable
   public abstract ResourceLocation getResourceLocation(@Nullable String path, boolean safe);
+
+  /**
+   * Gets the location of the given path in a specific language, ignoring the selected language.
+   * Used to load the English translations as a fallback for keys missing in the selected language.
+   * @param path      Path to find, relative to the repository
+   * @param language  Language to look in
+   * @return  Location of the file, or null if the repository has no copy of it in that language
+   */
+  @Nullable
+  public ResourceLocation getLanguageResourceLocation(@Nullable String path, String language) {
+    return null;
+  }
 
   /** Gets a resource from the given location */
   public abstract Optional<Resource> getLocation(@Nullable ResourceLocation loc);

--- a/src/main/java/slimeknights/mantle/client/book/repository/FileRepository.java
+++ b/src/main/java/slimeknights/mantle/client/book/repository/FileRepository.java
@@ -36,31 +36,14 @@ public class FileRepository extends BookRepository {
     }
 
     if (!path.contains(":")) {
-      String langPath = null;
-
-      //noinspection ConstantConditions - this was proven to be null once
-      if (Minecraft.getInstance().getLanguageManager() != null && Minecraft.getInstance().getLanguageManager().getSelected() != null) {
-        langPath = Minecraft.getInstance().getLanguageManager().getSelected();
-      }
-
-      String defaultLangPath = "en_us";
-
-      ResourceLocation res;
-
       // TODO: this can be optimized if we return the resource instead of the location, how feasible is that in practice?
-      //noinspection ConstantConditions - see above
-      if (langPath != null) {
-        res = new ResourceLocation(this.location + "/" + langPath + "/" + path);
-        if (this.resourceExists(res)) {
-          return res;
-        }
-      }
-      res = new ResourceLocation(this.location + "/" + defaultLangPath + "/" + path);
-      if (this.resourceExists(res)) {
+      ResourceLocation res = this.getLocalized(getSelectedLanguage(), path);
+      if (res != null) {
         return res;
       }
-      res = new ResourceLocation(this.location + "/" + path);
-      if (this.resourceExists(res)) {
+      // English, then the language agnostic root
+      res = this.getLanguageResourceLocation(path, DEFAULT_LANGUAGE);
+      if (res != null) {
         return res;
       }
     } else {
@@ -71,6 +54,31 @@ public class FileRepository extends BookRepository {
     }
 
     return safe ? new ResourceLocation("") : null;
+  }
+
+  @Nullable
+  @Override
+  public ResourceLocation getLanguageResourceLocation(@Nullable String path, String language) {
+    // paths with a namespace point at an exact file, so they have no language variants
+    if (path == null || path.contains(":")) {
+      return null;
+    }
+
+    ResourceLocation res = this.getLocalized(language, path);
+    if (res != null) {
+      return res;
+    }
+
+    // books are allowed to skip the language folder, those files act as the book's default language
+    res = new ResourceLocation(this.location + "/" + path);
+    return this.resourceExists(res) ? res : null;
+  }
+
+  /** Gets the location of the given path within the given language folder, or null if it does not exist */
+  @Nullable
+  private ResourceLocation getLocalized(String language, String path) {
+    ResourceLocation res = new ResourceLocation(this.location + "/" + language + "/" + path);
+    return this.resourceExists(res) ? res : null;
   }
 
   @Override

--- a/src/main/java/slimeknights/mantle/client/book/transformer/ContentGroupingSectionTransformer.java
+++ b/src/main/java/slimeknights/mantle/client/book/transformer/ContentGroupingSectionTransformer.java
@@ -40,6 +40,7 @@ public class ContentGroupingSectionTransformer extends SectionTransformer {
     String title = book.translate(sectionName);
     String subtextKey = sectionName + ".subtext";
     String subText = null;
+    // checks the selected language only; leaving the key out is how a language hides the subtext, so English must not fill it back in
     if (book.strings.containsKey(subtextKey)) {
       subText = book.translate(subtextKey);
     }

--- a/src/main/java/slimeknights/mantle/client/book/transformer/ContentListingSectionTransformer.java
+++ b/src/main/java/slimeknights/mantle/client/book/transformer/ContentListingSectionTransformer.java
@@ -29,6 +29,7 @@ public class ContentListingSectionTransformer extends SectionTransformer {
     listing.setCenterTitle(centerTitle);
     listing.title = book.translate(sectionName);
     String subtextKey = sectionName + ".subtext";
+    // checks the selected language only; leaving the key out is how a language hides the subtext, so English must not fill it back in
     if (book.strings.containsKey(subtextKey)) {
       listing.subText = book.translate(subtextKey);
     }


### PR DESCRIPTION
Book language files are picked per file, not per key: the cascade returns the first whole file it finds, so any key a language file omits renders as the raw translation key.

English now loads into a second map, `fallbackStrings`, and exactly one method reads it — `BookData#translate`, after `strings` and before giving up. Every place that treats a key's presence as a flag (the page title override and both listing transformers' subtext) keeps reading `strings` alone, so the fallback can change the text of an element that is already drawn but can never make one appear. Per the issue, English is only read when it isn't the selected language, and after loading, the map drops every key the language already defines — on Materials and You in Russian that keeps 9 of 15 keys, on the Encyclopedia 6 of 59.

Tested in game with the client set to Russian, which reproduces this with no setup — `ru_ru` genuinely omits six of the index keys `en_us` defines.

before: three of the seven section titles are raw keys
![before](https://raw.githubusercontent.com/ryancircelli/Mantle/pr-assets/232-before-index.png)

after: those three read in English, the four Russian titles untouched
![after](https://raw.githubusercontent.com/ryancircelli/Mantle/pr-assets/232-after-index.png)

control on the fixed build: an omitted optional subtext stays absent while a present one still renders in Russian
![omitted subtext stays absent](https://raw.githubusercontent.com/ryancircelli/Mantle/pr-assets/232-after-control-omitted-subtext-absent.png)
![present subtext still renders](https://raw.githubusercontent.com/ryancircelli/Mantle/pr-assets/232-after-control-present-subtext-shows.png)

One thing this deliberately does not fix: the Tools contents page still shows `group_general` and friends raw, since those go through `PageData#getTitle` — the presence read left alone. Consulting English after `content.getTitle()` would cover it without touching the override behavior; left out to keep the fallback single-reader, happy to add it if you'd rather have it in one go.

Report: #232
